### PR TITLE
JAT-74 Fix bug where user can't edit the first digit of a number that only has zeros after it

### DIFF
--- a/src/__tests__/unit_tests/NumberInput.test.tsx
+++ b/src/__tests__/unit_tests/NumberInput.test.tsx
@@ -245,7 +245,7 @@ describe('NumberInput', () => {
     expect(handleSubmit).toBeCalledWith(-2000);
   });
 
-  it('should be not be able to enter a zero with float notation for integer inputs', async () => {
+  it('should not be able to enter a zero with float notation for integer inputs', async () => {
     const testValue = 1;
     const { user } = setup(
       <NumberInput
@@ -273,7 +273,7 @@ describe('NumberInput', () => {
   });
 
   it('should be able to alter first digit in front of float with trailing zeros', async () => {
-    const testValue = 10.1;
+    const testValue = 10;
     const { user } = setup(
       <NumberInput
         name={id}
@@ -288,16 +288,16 @@ describe('NumberInput', () => {
     const input = screen.getByLabelText(id);
     expect(input).toHaveValue(`${testValue}`);
 
-    input.focus();
+    await clearAndType(user, input, '10.0');
     await user.keyboard('{ArrowLeft}{ArrowLeft}{ArrowLeft}{Backspace}2{Enter}');
-    expect(handleSubmit).toBeCalledWith(20.1);
+    expect(handleSubmit).toBeCalledWith(20);
 
-    await clearAndType(user, input, '-10.1');
+    await clearAndType(user, input, '-10.0');
     await user.keyboard('{ArrowLeft}{ArrowLeft}{ArrowLeft}{Backspace}2{Enter}');
-    expect(handleSubmit).toBeCalledWith(-20.1);
+    expect(handleSubmit).toBeCalledWith(-20);
   });
 
-  it('should be not be able to enter a zero with invalid float notation for float inputs', async () => {
+  it('should not be able to enter a zero with invalid float notation for float inputs', async () => {
     const testValue = 1;
     const { user } = setup(
       <NumberInput

--- a/src/renderer/widgets/NumberInput.tsx
+++ b/src/renderer/widgets/NumberInput.tsx
@@ -105,7 +105,7 @@ const NumberInput = ({
       // minus sign (- U+002D HYPHEN-MINUS), numeral (0–9), decimal point (.),
       // or exponent (e or E), it returns the value up to that character,
       // ignoring the invalid character and characters following it.
-      // We disallow e / E. We also disallow multiple -'ve signs or decimal points
+      // We disallow e / E, multiple -'ve signs and multiple decimal points
       if (
         input.match(/e|E/) ||
         (input.match(/-/g)?.length || 0) > 1 ||


### PR DESCRIPTION
- use old logic for input values that are non-zero
- if the input is zero then use a separate checker
  - for integers, only allow a string of all 0s (no decimal points, only one negative sign)
  - for floats, string can only contain 0s, at most one decimal point, at most one negative sign