### PR TITLE
JAT-80 JAT-81 UI tweaks and update modal buttons

### DIFF
--- a/src/renderer/MainContent.tsx
+++ b/src/renderer/MainContent.tsx
@@ -39,7 +39,7 @@ const MainContent = () => {
         <span className="rowLabel">Filter Type</span>
         <span className="rowLabel">Frequency (Hz)</span>
         <div className="col">
-          <span>30dB</span>
+          <span>+30dB</span>
           <span>0dB</span>
           <span>-30dB</span>
         </div>

--- a/src/renderer/PrereqMissingModal.tsx
+++ b/src/renderer/PrereqMissingModal.tsx
@@ -29,20 +29,20 @@ export default function PrereqMissingModal({
         </div>
         <div className="footer row">
           <Button
-            ariaLabel="Retry"
+            ariaLabel="Exit"
             isDisabled={isLoading}
-            className="small"
-            handleChange={onRetry}
-          >
-            Retry
-          </Button>
-          <Button
-            ariaLabel="Close"
-            isDisabled={isLoading}
-            className="small"
+            className="default"
             handleChange={handleClose}
           >
-            Close
+            Exit
+          </Button>
+          <Button
+            ariaLabel="Retry"
+            isDisabled={isLoading}
+            className="default"
+            handleChange={onRetry}
+          >
+            Close & Retry
           </Button>
         </div>
       </div>

--- a/src/renderer/styles/Button.scss
+++ b/src/renderer/styles/Button.scss
@@ -22,6 +22,10 @@ $button-height: 100px;
     height: fit-content;
   }
 
+  &.default {
+    padding: $spacing-s $spacing-m;
+  }
+
   path {
     fill: $white;
   }


### PR DESCRIPTION
## Changes
- Rename modal buttons to Exit and Close & Retry
- Swap modal button positions so the retry is on the bottom right
- Change 30dB to be +30dB
- Add more spacing around button text

Before
![image](https://user-images.githubusercontent.com/30204513/185217771-04c2471b-40ee-434d-a485-06c2764ed856.png)
After
![image](https://user-images.githubusercontent.com/30204513/185217759-d8f1d1f1-40f4-4286-aa52-7ccc110f62df.png)