### PR TITLE
JAT-83 Add points to the graph to visualize exact filter adjustment points

### DIFF
--- a/src/renderer/graph/Axis.tsx
+++ b/src/renderer/graph/Axis.tsx
@@ -1,5 +1,6 @@
 import * as d3 from 'd3';
 import { useEffect, useRef } from 'react';
+import { GrayScaleEnum } from '../styles/color';
 
 interface IAxisProps {
   type: 'bottom' | 'left';
@@ -37,7 +38,7 @@ const Axis = ({
       axisGroup
         .selectAll('text')
         .attr('opacity', 1)
-        .attr('color', 'white')
+        .attr('color', GrayScaleEnum.WHITE)
         .attr('font-size', '0.75rem');
     }
   }, [scale, tickValues, tickFormat, disableAnimation, type]);

--- a/src/renderer/graph/Chart.tsx
+++ b/src/renderer/graph/Chart.tsx
@@ -1,32 +1,22 @@
 import { useMemo } from 'react';
 import { ColorEnum } from '../styles/color';
 import Axis from './Axis';
-import Curve, {
-  AnimationOptionsEnum as CurveAnimationOptionsEnum,
-} from './Curve';
 import GridLine from './GridLine';
-import useController, {
-  ChartCurveData,
-  ChartPointsData,
-  MarginLike,
-} from './ChartController';
-import Points, {
-  AnimationOptionsEnum as PointsAnimationOptionsEnum,
-} from './Points';
+import useController, { IChartCurveData, IMarginLike } from './ChartController';
+import Curve from './Curve';
 
 export interface ChartDimensions {
   height: number;
   width: number;
-  margins: MarginLike;
+  margins: IMarginLike;
 }
 
 interface IChartProps {
-  data: ChartCurveData[];
+  data: IChartCurveData[];
   dimensions: ChartDimensions;
-  points: ChartPointsData[];
 }
 
-const Chart = ({ data = [], dimensions, points = [] }: IChartProps) => {
+const Chart = ({ data = [], dimensions }: IChartProps) => {
   const { width, height, margins } = dimensions;
   const svgWidth = useMemo(
     () => width - margins.left - margins.right,
@@ -91,28 +81,8 @@ const Chart = ({ data = [], dimensions, points = [] }: IChartProps) => {
         color={ColorEnum.COMPLEMENTARY}
         transform={`translate(${padding.left}, 0)`}
       />
-      {data.map((e: ChartCurveData) => (
-        <Curve
-          key={e.name}
-          name={e.name}
-          data={e.items}
-          xScale={xScaleFreq}
-          yScale={yScaleGain}
-          color={e.color}
-          width={e.width}
-          animation={CurveAnimationOptionsEnum.LEFT}
-        />
-      ))}
-      {points.map((e: ChartPointsData) => (
-        <Points
-          key={e.name}
-          name={e.name}
-          data={e.items}
-          xScale={xScaleFreq}
-          yScale={yScaleGain}
-          color={e.color}
-          animation={PointsAnimationOptionsEnum.FADE_IN}
-        />
+      {data.map((e: IChartCurveData) => (
+        <Curve key={e.id} data={e} xScale={xScaleFreq} yScale={yScaleGain} />
       ))}
       <Axis
         type="left"

--- a/src/renderer/graph/Chart.tsx
+++ b/src/renderer/graph/Chart.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { ColorEnum } from '../styles/color';
 import Axis from './Axis';
 import Curve, {
   AnimationOptionsEnum as CurveAnimationOptionsEnum,
@@ -87,7 +88,7 @@ const Chart = ({ data = [], dimensions, points = [] }: IChartProps) => {
         scale={yScaleGain}
         tickValues={[0]}
         size={width - margins.left - margins.right}
-        color="#F7844F"
+        color={ColorEnum.COMPLEMENTARY}
         transform={`translate(${padding.left}, 0)`}
       />
       {data.map((e: ChartCurveData) => (
@@ -98,6 +99,7 @@ const Chart = ({ data = [], dimensions, points = [] }: IChartProps) => {
           xScale={xScaleFreq}
           yScale={yScaleGain}
           color={e.color}
+          width={e.width}
           animation={CurveAnimationOptionsEnum.LEFT}
         />
       ))}

--- a/src/renderer/graph/Chart.tsx
+++ b/src/renderer/graph/Chart.tsx
@@ -2,7 +2,12 @@ import { useMemo } from 'react';
 import Axis from './Axis';
 import Curve, { AnimationOptionsEnum } from './Curve';
 import GridLine from './GridLine';
-import useController, { ChartData, MarginLike } from './ChartController';
+import useController, {
+  ChartCurveData,
+  ChartPointsData,
+  MarginLike,
+} from './ChartController';
+import Points from './Points';
 
 export interface ChartDimensions {
   height: number;
@@ -11,11 +16,12 @@ export interface ChartDimensions {
 }
 
 interface IChartProps {
-  data: ChartData[];
+  data: ChartCurveData[];
   dimensions: ChartDimensions;
+  points: ChartPointsData[];
 }
 
-const Chart = ({ data = [], dimensions }: IChartProps) => {
+const Chart = ({ data = [], dimensions, points = [] }: IChartProps) => {
   const { width, height, margins } = dimensions;
   const svgWidth = useMemo(
     () => width - margins.left - margins.right,
@@ -80,7 +86,7 @@ const Chart = ({ data = [], dimensions }: IChartProps) => {
         color="#F7844F"
         transform={`translate(${padding.left}, 0)`}
       />
-      {data.map((e: ChartData) => (
+      {data.map((e: ChartCurveData) => (
         <Curve
           key={e.name}
           name={e.name}
@@ -89,6 +95,17 @@ const Chart = ({ data = [], dimensions }: IChartProps) => {
           yScale={yScaleGain}
           color={e.color}
           animation={AnimationOptionsEnum.LEFT}
+        />
+      ))}
+      {points.map((e: ChartPointsData) => (
+        <Points
+          key={e.name}
+          name={e.name}
+          data={e.items}
+          xScale={xScaleFreq}
+          yScale={yScaleGain}
+          color={e.color}
+          animation={AnimationOptionsEnum.NONE}
         />
       ))}
       <Axis

--- a/src/renderer/graph/Chart.tsx
+++ b/src/renderer/graph/Chart.tsx
@@ -1,13 +1,17 @@
 import { useMemo } from 'react';
 import Axis from './Axis';
-import Curve, { AnimationOptionsEnum } from './Curve';
+import Curve, {
+  AnimationOptionsEnum as CurveAnimationOptionsEnum,
+} from './Curve';
 import GridLine from './GridLine';
 import useController, {
   ChartCurveData,
   ChartPointsData,
   MarginLike,
 } from './ChartController';
-import Points from './Points';
+import Points, {
+  AnimationOptionsEnum as PointsAnimationOptionsEnum,
+} from './Points';
 
 export interface ChartDimensions {
   height: number;
@@ -94,7 +98,7 @@ const Chart = ({ data = [], dimensions, points = [] }: IChartProps) => {
           xScale={xScaleFreq}
           yScale={yScaleGain}
           color={e.color}
-          animation={AnimationOptionsEnum.LEFT}
+          animation={CurveAnimationOptionsEnum.LEFT}
         />
       ))}
       {points.map((e: ChartPointsData) => (
@@ -105,7 +109,7 @@ const Chart = ({ data = [], dimensions, points = [] }: IChartProps) => {
           xScale={xScaleFreq}
           yScale={yScaleGain}
           color={e.color}
-          animation={AnimationOptionsEnum.NONE}
+          animation={PointsAnimationOptionsEnum.FADE_IN}
         />
       ))}
       <Axis

--- a/src/renderer/graph/ChartController.tsx
+++ b/src/renderer/graph/ChartController.tsx
@@ -4,40 +4,40 @@ import * as d3 from 'd3';
 export const GRAPH_START = 10;
 export const GRAPH_END = 25000;
 
-export interface ChartDataPoint {
-  x: number;
-  y: number;
-}
-
-export interface ChartDataPointWithId extends ChartDataPoint {
-  id: string;
-}
-
-export interface MarginLike {
+export interface IMarginLike {
   left: number;
   top: number;
   right: number;
   bottom: number;
 }
 
-export interface ChartCurveData {
-  name: string;
-  color: string;
-  width: number;
-  items: ChartDataPoint[];
+export interface IChartPointData {
+  x: number;
+  y: number;
 }
 
-export interface ChartPointsData {
-  name: string;
+export interface IChartLineDataPointsById {
+  [id: string]: IChartPointData[];
+}
+
+export interface IChartLineData {
   color: string;
-  items: ChartDataPointWithId[];
+  strokeWidth: number;
+  points: IChartPointData[];
+}
+
+export interface IChartCurveData {
+  id: string;
+  name: string;
+  line: IChartLineData;
+  point?: IChartPointData;
 }
 
 interface IChartControllerProps {
-  data: ChartCurveData[];
+  data: IChartCurveData[];
   width: number;
   height: number;
-  padding: MarginLike;
+  padding: IMarginLike;
 }
 
 const useController = ({
@@ -47,12 +47,12 @@ const useController = ({
   padding,
 }: IChartControllerProps) => {
   const xMin = useMemo(
-    () => d3.min(data, ({ items }) => d3.min(items, ({ x }) => x)) || 0,
+    () => d3.min(data, ({ line }) => d3.min(line.points, ({ x }) => x)) || 0,
     [data]
   );
 
   const xMax = useMemo(
-    () => d3.max(data, ({ items }) => d3.max(items, ({ x }) => x)) || 0,
+    () => d3.max(data, ({ line }) => d3.max(line.points, ({ x }) => x)) || 0,
     [data]
   );
 
@@ -66,12 +66,12 @@ const useController = ({
   );
 
   const yMin = useMemo(
-    () => d3.min(data, ({ items }) => d3.min(items, ({ y }) => y)) || 0,
+    () => d3.min(data, ({ line }) => d3.min(line.points, ({ y }) => y)) || 0,
     [data]
   );
 
   const yMax = useMemo(
-    () => d3.max(data, ({ items }) => d3.max(items, ({ y }) => y)) || 0,
+    () => d3.max(data, ({ line }) => d3.max(line.points, ({ y }) => y)) || 0,
     [data]
   );
 

--- a/src/renderer/graph/ChartController.tsx
+++ b/src/renderer/graph/ChartController.tsx
@@ -1,8 +1,12 @@
 import { useMemo } from 'react';
 import * as d3 from 'd3';
+import { Color } from 'renderer/styles/color';
 
 export const GRAPH_START = 10;
 export const GRAPH_END = 25000;
+
+export const INIT_ANIMATE_DURATION = 750;
+export const GRAPH_ANIMATE_DURATION = 100;
 
 export interface IMarginLike {
   left: number;
@@ -20,17 +24,15 @@ export interface IChartLineDataPointsById {
   [id: string]: IChartPointData[];
 }
 
-export interface IChartLineData {
-  color: string;
-  strokeWidth: number;
-  points: IChartPointData[];
-}
-
 export interface IChartCurveData {
   id: string;
   name: string;
-  line: IChartLineData;
-  point?: IChartPointData;
+  line: {
+    color: Color;
+    strokeWidth: number;
+    points: IChartPointData[];
+  };
+  controlPoint?: IChartPointData;
 }
 
 interface IChartControllerProps {

--- a/src/renderer/graph/ChartController.tsx
+++ b/src/renderer/graph/ChartController.tsx
@@ -9,6 +9,10 @@ export interface ChartDataPoint {
   y: number;
 }
 
+export interface ChartDataPointWithId extends ChartDataPoint {
+  id: string;
+}
+
 export interface MarginLike {
   left: number;
   top: number;
@@ -16,14 +20,20 @@ export interface MarginLike {
   bottom: number;
 }
 
-export interface ChartData {
+export interface ChartCurveData {
   name: string;
   color: string; // #ffffff, white, rgba(255, 255, 255, 0.5)
   items: ChartDataPoint[];
 }
 
+export interface ChartPointsData {
+  name: string;
+  color: string; // #ffffff, white, rgba(255, 255, 255, 0.5)
+  items: ChartDataPointWithId[];
+}
+
 interface IChartControllerProps {
-  data: ChartData[];
+  data: ChartCurveData[];
   width: number;
   height: number;
   padding: MarginLike;

--- a/src/renderer/graph/ChartController.tsx
+++ b/src/renderer/graph/ChartController.tsx
@@ -22,13 +22,14 @@ export interface MarginLike {
 
 export interface ChartCurveData {
   name: string;
-  color: string; // #ffffff, white, rgba(255, 255, 255, 0.5)
+  color: string;
+  width: number;
   items: ChartDataPoint[];
 }
 
 export interface ChartPointsData {
   name: string;
-  color: string; // #ffffff, white, rgba(255, 255, 255, 0.5)
+  color: string;
   items: ChartDataPointWithId[];
 }
 

--- a/src/renderer/graph/Curve.tsx
+++ b/src/renderer/graph/Curve.tsx
@@ -13,6 +13,7 @@ interface ICurveProps {
   xScale: d3.AxisScale<d3.NumberValue>;
   yScale: d3.AxisScale<d3.NumberValue>;
   color: string;
+  width: number;
   data: ChartDataPoint[];
   animation?: AnimationOptionsEnum;
   transform?: string;
@@ -23,6 +24,7 @@ const Curve = ({
   xScale,
   yScale,
   color = 'white',
+  width = 3,
   data = [],
   animation = AnimationOptionsEnum.NONE,
   transform,
@@ -93,7 +95,7 @@ const Curve = ({
       name={name}
       ref={ref}
       stroke={color}
-      strokeWidth={3}
+      strokeWidth={width}
       fill="none"
       opacity={0}
       d={d || ''}

--- a/src/renderer/graph/Curve.tsx
+++ b/src/renderer/graph/Curve.tsx
@@ -13,7 +13,7 @@ interface ICurveProps {
 }
 
 const Curve = ({ xScale, yScale, data }: ICurveProps) => {
-  const { name, line, point } = data;
+  const { name, line, controlPoint } = data;
 
   return (
     <>
@@ -26,10 +26,10 @@ const Curve = ({ xScale, yScale, data }: ICurveProps) => {
         strokeWidth={line.strokeWidth}
         animation={LineAnimationOptionsEnum.LEFT}
       />
-      {point && (
+      {controlPoint && (
         <Point
           name={name}
-          data={point}
+          data={controlPoint}
           xScale={xScale}
           yScale={yScale}
           color={SecondaryColorEnum.DEFAULT}

--- a/src/renderer/graph/Curve.tsx
+++ b/src/renderer/graph/Curve.tsx
@@ -1,106 +1,43 @@
 import * as d3 from 'd3';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { ChartDataPoint } from './ChartController';
-
-export enum AnimationOptionsEnum {
-  LEFT = 'left',
-  FADE_IN = 'fadeIn',
-  NONE = 'none',
-}
+import { SecondaryColorEnum } from 'renderer/styles/color';
+import { IChartCurveData } from './ChartController';
+import Line, { AnimationOptionsEnum as LineAnimationOptionsEnum } from './Line';
+import Point, {
+  AnimationOptionsEnum as PointAnimationOptionsEnum,
+} from './Point';
 
 interface ICurveProps {
-  name: string;
   xScale: d3.AxisScale<d3.NumberValue>;
   yScale: d3.AxisScale<d3.NumberValue>;
-  color: string;
-  width: number;
-  data: ChartDataPoint[];
-  animation?: AnimationOptionsEnum;
-  transform?: string;
+  data: IChartCurveData;
 }
 
-const Curve = ({
-  name,
-  xScale,
-  yScale,
-  color = 'white',
-  width = 3,
-  data = [],
-  animation = AnimationOptionsEnum.NONE,
-  transform,
-}: ICurveProps) => {
-  const ref = useRef<SVGPathElement>(null);
-  // Define different types of animation that we can use
-  const animateLeft = useCallback(() => {
-    const totalLength = ref.current ? ref.current.getTotalLength() : 100;
-    d3.select(ref.current)
-      .attr('opacity', 1)
-      .attr('stroke-dasharray', `${totalLength} ${totalLength}`)
-      .attr('stroke-dashoffset', totalLength)
-      .transition()
-      .duration(750)
-      .ease(d3.easeLinear)
-      .attr('stroke-dashoffset', 0);
-  }, []);
-
-  const animateFadeIn = useCallback(() => {
-    d3.select(ref.current)
-      .transition()
-      .duration(750)
-      .ease(d3.easeLinear)
-      .attr('opacity', 1);
-  }, []);
-
-  const noneAnimation = useCallback(() => {
-    d3.select(ref.current).attr('opacity', 1);
-  }, []);
-
-  useEffect(() => {
-    switch (animation) {
-      case AnimationOptionsEnum.LEFT:
-        animateLeft();
-        break;
-      case AnimationOptionsEnum.FADE_IN:
-        animateFadeIn();
-        break;
-      case AnimationOptionsEnum.NONE:
-      default:
-        noneAnimation();
-        break;
-    }
-  }, [animateLeft, animateFadeIn, noneAnimation, animation]);
-
-  // Recalculate line length if scale or data has changed
-  useEffect(() => {
-    const totalLength = ref.current ? ref.current.getTotalLength() : 100;
-    d3.select(ref.current).attr(
-      'stroke-dasharray',
-      `${totalLength} ${totalLength}`
-    );
-  }, [xScale, yScale, data]);
-
-  const line = useMemo(
-    () =>
-      d3
-        .line<ChartDataPoint>()
-        .x(({ x }) => xScale(x) || 0)
-        .y(({ y }) => yScale(y) || 0),
-    [xScale, yScale]
-  );
-
-  const d = useMemo(() => line(data), [data, line]);
+const Curve = ({ xScale, yScale, data }: ICurveProps) => {
+  const { name, line, point } = data;
 
   return (
-    <path
-      name={name}
-      ref={ref}
-      stroke={color}
-      strokeWidth={width}
-      fill="none"
-      opacity={0}
-      d={d || ''}
-      transform={transform}
-    />
+    <>
+      <Line
+        name={name}
+        data={line.points}
+        xScale={xScale}
+        yScale={yScale}
+        color={line.color}
+        strokeWidth={line.strokeWidth}
+        animation={LineAnimationOptionsEnum.LEFT}
+      />
+      {point && (
+        <Point
+          name={name}
+          data={point}
+          xScale={xScale}
+          yScale={yScale}
+          color={SecondaryColorEnum.DEFAULT}
+          radius={4}
+          animation={PointAnimationOptionsEnum.FADE_IN}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/renderer/graph/Curve.tsx
+++ b/src/renderer/graph/Curve.tsx
@@ -1,6 +1,5 @@
 import * as d3 from 'd3';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useIsNotFirstRender } from 'renderer/utils/utils';
 import { ChartDataPoint } from './ChartController';
 
 export enum AnimationOptionsEnum {
@@ -69,16 +68,14 @@ const Curve = ({
     }
   }, [animateLeft, animateFadeIn, noneAnimation, animation]);
 
-  // Recalculate line length if scale has changed
+  // Recalculate line length if scale or data has changed
   useEffect(() => {
-    if (animation === AnimationOptionsEnum.LEFT) {
-      const totalLength = ref.current ? ref.current.getTotalLength() : 100;
-      d3.select(ref.current).attr(
-        'stroke-dasharray',
-        `${totalLength} ${totalLength}`
-      );
-    }
-  }, [xScale, yScale, animation]);
+    const totalLength = ref.current ? ref.current.getTotalLength() : 100;
+    d3.select(ref.current).attr(
+      'stroke-dasharray',
+      `${totalLength} ${totalLength}`
+    );
+  }, [xScale, yScale, data]);
 
   const line = useMemo(
     () =>
@@ -90,20 +87,6 @@ const Curve = ({
   );
 
   const d = useMemo(() => line(data), [data, line]);
-  const isNotFirstRender = useIsNotFirstRender();
-
-  useEffect(() => {
-    // Animate changes to the curve on subsequent renders
-    if (ref.current && isNotFirstRender) {
-      const totalLength = ref.current ? ref.current.getTotalLength() : 100;
-      d3.select(ref.current)
-        // Adjust line length to match new curve
-        .attr('stroke-dasharray', `${totalLength} ${totalLength}`)
-        .transition()
-        .duration(500)
-        .attr('d', d);
-    }
-  }, [d, isNotFirstRender]);
 
   return (
     <path

--- a/src/renderer/graph/FrequencyResponseChart.tsx
+++ b/src/renderer/graph/FrequencyResponseChart.tsx
@@ -37,7 +37,7 @@ const FrequencyResponseChart = () => {
   const prevFilterLines = useRef<IChartLineDataPointsById>({});
 
   const { chartData, autoPreAmpValue }: IGraphData = useMemo(() => {
-    const pointById: { [id: string]: IChartPointData } = {};
+    const controlPointByCurveId: { [id: string]: IChartPointData } = {};
 
     // Identify the index of each filter by id from previous render
     const prevIndices: { [id: string]: number } = {};
@@ -50,7 +50,10 @@ const FrequencyResponseChart = () => {
     // Update filter lines that have changed
     filters.forEach((filter) => {
       // Store control point info
-      pointById[filter.id] = { x: filter.frequency, y: filter.gain };
+      controlPointByCurveId[filter.id] = {
+        x: filter.frequency,
+        y: filter.gain,
+      };
 
       // New filters have no previous data
       const prevIndex = prevIndices[filter.id];
@@ -118,7 +121,7 @@ const FrequencyResponseChart = () => {
               strokeWidth: 2,
               points: updatedFilterLines[id],
             },
-            point: pointById[id],
+            controlPoint: controlPointByCurveId[id],
           } as IChartCurveData;
         }),
       ],

--- a/src/renderer/graph/Line.tsx
+++ b/src/renderer/graph/Line.tsx
@@ -113,6 +113,10 @@ const Line = ({
         // Adjust line length to match new curve
         .attr('stroke-dasharray', `${totalLength} ${totalLength}`)
         .transition()
+        // Make sure initial animation is overwritten
+        .attr('opacity', 1)
+        .attr('stroke-dashoffset', 0)
+        // Add new animation
         .duration(GRAPH_ANIMATE_DURATION)
         .attr('d', d);
     }

--- a/src/renderer/graph/Line.tsx
+++ b/src/renderer/graph/Line.tsx
@@ -107,15 +107,12 @@ const Line = ({
   // Handle animation for subsequent renders
   useEffect(() => {
     if (ref.current && !isFirstRender) {
-      // Recalculate line length if scale or data has changed
-      const totalLength = ref.current ? ref.current.getTotalLength() : 100;
       d3.select(ref.current)
-        // Adjust line length to match new curve
-        .attr('stroke-dasharray', `${totalLength} ${totalLength}`)
-        .transition()
         // Make sure initial animation is overwritten
+        .attr('stroke-dasharray', null)
+        .attr('stroke-offset', null)
         .attr('opacity', 1)
-        .attr('stroke-dashoffset', 0)
+        .transition()
         // Add new animation
         .duration(GRAPH_ANIMATE_DURATION)
         .attr('d', d);

--- a/src/renderer/graph/Line.tsx
+++ b/src/renderer/graph/Line.tsx
@@ -1,0 +1,107 @@
+import * as d3 from 'd3';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { IChartPointData } from './ChartController';
+
+export enum AnimationOptionsEnum {
+  LEFT = 'left',
+  FADE_IN = 'fadeIn',
+  NONE = 'none',
+}
+
+interface ILineProps {
+  name: string;
+  xScale: d3.AxisScale<d3.NumberValue>;
+  yScale: d3.AxisScale<d3.NumberValue>;
+  color: string;
+  strokeWidth: number;
+  data: IChartPointData[];
+  animation?: AnimationOptionsEnum;
+  transform?: string;
+}
+
+const Line = ({
+  name,
+  xScale,
+  yScale,
+  color = 'white',
+  strokeWidth = 3,
+  data = [],
+  animation = AnimationOptionsEnum.NONE,
+  transform,
+}: ILineProps) => {
+  const ref = useRef<SVGPathElement>(null);
+  // Define different types of animation that we can use
+  const animateLeft = useCallback(() => {
+    const totalLength = ref.current ? ref.current.getTotalLength() : 100;
+    d3.select(ref.current)
+      .attr('opacity', 1)
+      .attr('stroke-dasharray', `${totalLength} ${totalLength}`)
+      .attr('stroke-dashoffset', totalLength)
+      .transition()
+      .duration(750)
+      .ease(d3.easeLinear)
+      .attr('stroke-dashoffset', 0);
+  }, []);
+
+  const animateFadeIn = useCallback(() => {
+    d3.select(ref.current)
+      .transition()
+      .duration(750)
+      .ease(d3.easeLinear)
+      .attr('opacity', 1);
+  }, []);
+
+  const noneAnimation = useCallback(() => {
+    d3.select(ref.current).attr('opacity', 1);
+  }, []);
+
+  useEffect(() => {
+    switch (animation) {
+      case AnimationOptionsEnum.LEFT:
+        animateLeft();
+        break;
+      case AnimationOptionsEnum.FADE_IN:
+        animateFadeIn();
+        break;
+      case AnimationOptionsEnum.NONE:
+      default:
+        noneAnimation();
+        break;
+    }
+  }, [animateLeft, animateFadeIn, noneAnimation, animation]);
+
+  // Recalculate line length if scale or data has changed
+  useEffect(() => {
+    const totalLength = ref.current ? ref.current.getTotalLength() : 100;
+    d3.select(ref.current).attr(
+      'stroke-dasharray',
+      `${totalLength} ${totalLength}`
+    );
+  }, [xScale, yScale, data]);
+
+  const line = useMemo(
+    () =>
+      d3
+        .line<IChartPointData>()
+        .x(({ x }) => xScale(x) || 0)
+        .y(({ y }) => yScale(y) || 0),
+    [xScale, yScale]
+  );
+
+  const d = useMemo(() => line(data), [data, line]);
+
+  return (
+    <path
+      name={name}
+      ref={ref}
+      stroke={color}
+      strokeWidth={strokeWidth}
+      fill="none"
+      opacity={0}
+      d={d || ''}
+      transform={transform}
+    />
+  );
+};
+
+export default Line;

--- a/src/renderer/graph/Point.tsx
+++ b/src/renderer/graph/Point.tsx
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { ChartDataPointWithId } from './ChartController';
+import { IChartPointData } from './ChartController';
 
 export enum AnimationOptionsEnum {
   FADE_IN = 'fadeIn',
@@ -9,7 +9,9 @@ export enum AnimationOptionsEnum {
 
 interface IPointProps {
   name: string;
-  pointData: ChartDataPointWithId;
+  xScale: d3.AxisScale<d3.NumberValue>;
+  yScale: d3.AxisScale<d3.NumberValue>;
+  data: IChartPointData;
   radius: number;
   color: string;
   animation?: AnimationOptionsEnum;
@@ -18,14 +20,19 @@ interface IPointProps {
 
 const Point = ({
   name,
-  pointData,
+  xScale,
+  yScale,
+  data,
   radius,
   color,
   animation,
   transform,
 }: IPointProps) => {
   const ref = useRef<SVGCircleElement>(null);
-  const { id, x, y } = pointData;
+  const { x, y } = data;
+
+  const scaledX = useMemo(() => xScale(x) || 0, [x, xScale]);
+  const scaledY = useMemo(() => yScale(y) || 0, [y, yScale]);
 
   const animateFadeIn = useCallback(() => {
     if (ref.current) {
@@ -58,65 +65,15 @@ const Point = ({
   return (
     <circle
       ref={ref}
-      key={id}
-      id={id}
       name={name}
       r={radius}
       fill={color}
       stroke="#ffffff"
       transform={transform}
-      cx={x}
-      cy={y}
+      cx={scaledX}
+      cy={scaledY}
     />
   );
 };
 
-interface IPointsProps {
-  name: string;
-  xScale: d3.AxisScale<d3.NumberValue>;
-  yScale: d3.AxisScale<d3.NumberValue>;
-  color: string;
-  data: ChartDataPointWithId[];
-  animation?: AnimationOptionsEnum;
-  transform?: string;
-}
-
-const Points = ({
-  name,
-  xScale,
-  yScale,
-  color = 'white',
-  data = [],
-  animation = AnimationOptionsEnum.NONE,
-  transform,
-}: IPointsProps) => {
-  const scaledPoints = useMemo(
-    () =>
-      data.map(({ x, y, id }) => {
-        return {
-          x: xScale(x) || 0,
-          y: yScale(y) || 0,
-          id,
-        };
-      }),
-    [data, xScale, yScale]
-  );
-
-  return (
-    <>
-      {scaledPoints.map((point) => (
-        <Point
-          key={point.id}
-          name={name}
-          pointData={point}
-          radius={4}
-          color={color}
-          transform={transform}
-          animation={animation}
-        />
-      ))}
-    </>
-  );
-};
-
-export default Points;
+export default Point;

--- a/src/renderer/graph/Point.tsx
+++ b/src/renderer/graph/Point.tsx
@@ -85,6 +85,9 @@ const Point = ({
     if (ref.current && !isFirstRender) {
       d3.select(ref.current)
         .transition()
+        // Make sure initial animation is overwritten
+        .attr('opacity', 1)
+        // Add new animation
         .duration(GRAPH_ANIMATE_DURATION)
         .attr('cx', scaledX)
         .attr('cy', scaledY);

--- a/src/renderer/graph/Points.tsx
+++ b/src/renderer/graph/Points.tsx
@@ -1,6 +1,5 @@
 import * as d3 from 'd3';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useIsNotFirstRender } from 'renderer/utils/utils';
 import { ChartDataPoint, ChartDataPointWithId } from './ChartController';
 
 export enum AnimationOptionsEnum {
@@ -71,6 +70,7 @@ const Points = ({
     [data, xScale, yScale]
   );
 
+  // Map points from filter id to coordinate
   const scaledPointsMap = useMemo(() => {
     const map: { [id: string]: ChartDataPoint } = {};
     scaledPoints.forEach((point) => {
@@ -79,33 +79,20 @@ const Points = ({
     return map;
   }, [scaledPoints]);
 
-  const isNotFirstRender = useIsNotFirstRender();
-
-  // TODO: figure out how to best customize when to animate
-  //    - either none or fade animate when adding a new point
-  //    - no animation when a frequency is changed
-  const animatePoints = useMemo(() => isNotFirstRender, [isNotFirstRender]);
-
+  // Update point location when changes are made
   useEffect(() => {
     if (refs.current) {
       refs.current
+        // filter out refs for which we don't have coordinates
         ?.filter(({ id }) => id in scaledPointsMap)
         .forEach((r) =>
-          // Only animate for subsequent renders
-          animatePoints
-            ? d3
-                .select(r)
-                .transition()
-                .duration(500)
-                .attr('cx', scaledPointsMap[r.id].x)
-                .attr('cy', scaledPointsMap[r.id].y)
-            : d3
-                .select(r)
-                .attr('cx', scaledPointsMap[r.id].x)
-                .attr('cy', scaledPointsMap[r.id].y)
+          d3
+            .select(r)
+            .attr('cx', scaledPointsMap[r.id].x)
+            .attr('cy', scaledPointsMap[r.id].y)
         );
     }
-  }, [animatePoints, scaledPointsMap]);
+  }, [scaledPointsMap]);
 
   return (
     <>
@@ -122,6 +109,7 @@ const Points = ({
           r={4}
           fill={color}
           stroke="#ffffff"
+          transform={transform}
         />
       ))}
     </>

--- a/src/renderer/graph/Points.tsx
+++ b/src/renderer/graph/Points.tsx
@@ -1,0 +1,133 @@
+import * as d3 from 'd3';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { ChartDataPoint, ChartDataPointWithId } from './ChartController';
+
+export enum AnimationOptionsEnum {
+  LEFT = 'left',
+  FADE_IN = 'fadeIn',
+  NONE = 'none',
+}
+
+interface IPointsProps {
+  name: string;
+  xScale: d3.AxisScale<d3.NumberValue>;
+  yScale: d3.AxisScale<d3.NumberValue>;
+  color: string;
+  data: ChartDataPointWithId[];
+  animation?: AnimationOptionsEnum;
+  transform?: string;
+}
+
+const Points = ({
+  name,
+  xScale,
+  yScale,
+  color = 'white',
+  data = [],
+  animation = AnimationOptionsEnum.NONE,
+  transform,
+}: IPointsProps) => {
+  const refs = useRef<SVGPathElement[]>([]);
+  // Define different types of animation that we can use
+  const animateLeft = useCallback(() => {
+    // const totalLength = refs.current ? refs.current.getTotalLength() : 100;
+    refs.current?.forEach((r) =>
+      d3
+        .select(r)
+        .attr('opacity', 1)
+        // .attr('stroke-dasharray', `${totalLength},${totalLength}`)
+        // .attr('stroke-dashoffset', totalLength)
+        .transition()
+        .duration(750)
+        .ease(d3.easeLinear)
+    );
+    // .attr('stroke-dashoffset', 0);
+  }, []);
+
+  const animateFadeIn = useCallback(() => {
+    refs.current?.forEach((r) =>
+      d3
+        .select(r)
+        .transition()
+        .duration(750)
+        .ease(d3.easeLinear)
+        .attr('opacity', 1)
+    );
+  }, []);
+
+  const noneAnimation = useCallback(() => {
+    refs.current?.forEach((r) => d3.select(r).attr('opacity', 1));
+  }, []);
+
+  useEffect(() => {
+    switch (animation) {
+      case AnimationOptionsEnum.LEFT:
+        animateLeft();
+        break;
+      case AnimationOptionsEnum.FADE_IN:
+        animateFadeIn();
+        break;
+      case AnimationOptionsEnum.NONE:
+      default:
+        noneAnimation();
+        break;
+    }
+  }, [animateLeft, animateFadeIn, noneAnimation, animation]);
+
+  const scaledPoints = useMemo(
+    () =>
+      data.map(({ x, y, id }) => {
+        return {
+          x: xScale(x) || 0,
+          y: yScale(y) || 0,
+          id,
+        };
+      }),
+    [data, xScale, yScale]
+  );
+
+  const scaledPointsMap = useMemo(() => {
+    const map: { [id: string]: ChartDataPoint } = {};
+    scaledPoints.forEach((point) => {
+      map[point.id] = { x: point.x, y: point.y };
+    });
+    return map;
+  }, [scaledPoints]);
+
+  useEffect(() => {
+    if (refs.current) {
+      refs.current
+        ?.filter(({ id }) => id in scaledPointsMap)
+        .forEach((r) =>
+          d3
+            .select(r)
+            .transition()
+            .duration(500)
+            .attr('cx', scaledPointsMap[r.id].x)
+            .attr('cy', scaledPointsMap[r.id].y)
+        );
+    }
+  }, [scaledPointsMap]);
+
+  return (
+    <>
+      {scaledPoints.map(({ id }) => (
+        <circle
+          key={id}
+          id={id}
+          name={name}
+          ref={(element) => {
+            if (element) {
+              refs.current.push(element);
+            }
+          }}
+          r={4}
+          fill={color}
+          stroke="#ffffff"
+        />
+      ))}
+    </>
+  );
+};
+
+export default Points;

--- a/src/renderer/graph/Points.tsx
+++ b/src/renderer/graph/Points.tsx
@@ -1,11 +1,75 @@
 import * as d3 from 'd3';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { ChartDataPoint, ChartDataPointWithId } from './ChartController';
+import { ChartDataPointWithId } from './ChartController';
 
 export enum AnimationOptionsEnum {
   FADE_IN = 'fadeIn',
   NONE = 'none',
 }
+
+interface IPointProps {
+  name: string;
+  pointData: ChartDataPointWithId;
+  radius: number;
+  color: string;
+  animation?: AnimationOptionsEnum;
+  transform?: string;
+}
+
+const Point = ({
+  name,
+  pointData,
+  radius,
+  color,
+  animation,
+  transform,
+}: IPointProps) => {
+  const ref = useRef<SVGCircleElement>(null);
+  const { id, x, y } = pointData;
+
+  const animateFadeIn = useCallback(() => {
+    if (ref.current) {
+      d3.select(ref.current)
+        .transition()
+        .duration(750)
+        .ease(d3.easeLinear)
+        .attr('opacity', 1);
+    }
+  }, []);
+
+  const noneAnimation = useCallback(() => {
+    if (ref.current) {
+      d3.select(ref.current).attr('opacity', 1);
+    }
+  }, []);
+
+  useEffect(() => {
+    switch (animation) {
+      case AnimationOptionsEnum.FADE_IN:
+        animateFadeIn();
+        break;
+      case AnimationOptionsEnum.NONE:
+      default:
+        noneAnimation();
+        break;
+    }
+  }, [animateFadeIn, noneAnimation, animation]);
+
+  return (
+    <circle
+      ref={ref}
+      key={id}
+      id={id}
+      name={name}
+      r={radius}
+      fill={color}
+      stroke="#ffffff"
+      transform={transform}
+      cx={x}
+      cy={y}
+    />
+  );
+};
 
 interface IPointsProps {
   name: string;
@@ -26,38 +90,6 @@ const Points = ({
   animation = AnimationOptionsEnum.NONE,
   transform,
 }: IPointsProps) => {
-  const refs = useRef<SVGPathElement[]>([]);
-  useEffect(() => {
-    refs.current = refs.current.slice(0, data.length);
-  }, [data]);
-
-  const animateFadeIn = useCallback(() => {
-    refs.current?.forEach((r) =>
-      d3
-        .select(r)
-        .transition()
-        .duration(750)
-        .ease(d3.easeLinear)
-        .attr('opacity', 1)
-    );
-  }, []);
-
-  const noneAnimation = useCallback(() => {
-    refs.current?.forEach((r) => d3.select(r).attr('opacity', 1));
-  }, []);
-
-  useEffect(() => {
-    switch (animation) {
-      case AnimationOptionsEnum.FADE_IN:
-        animateFadeIn();
-        break;
-      case AnimationOptionsEnum.NONE:
-      default:
-        noneAnimation();
-        break;
-    }
-  }, [animateFadeIn, noneAnimation, animation]);
-
   const scaledPoints = useMemo(
     () =>
       data.map(({ x, y, id }) => {
@@ -70,46 +102,17 @@ const Points = ({
     [data, xScale, yScale]
   );
 
-  // Map points from filter id to coordinate
-  const scaledPointsMap = useMemo(() => {
-    const map: { [id: string]: ChartDataPoint } = {};
-    scaledPoints.forEach((point) => {
-      map[point.id] = { x: point.x, y: point.y };
-    });
-    return map;
-  }, [scaledPoints]);
-
-  // Update point location when changes are made
-  useEffect(() => {
-    if (refs.current) {
-      refs.current
-        // filter out refs for which we don't have coordinates
-        ?.filter(({ id }) => id in scaledPointsMap)
-        .forEach((r) =>
-          d3
-            .select(r)
-            .attr('cx', scaledPointsMap[r.id].x)
-            .attr('cy', scaledPointsMap[r.id].y)
-        );
-    }
-  }, [scaledPointsMap]);
-
   return (
     <>
-      {scaledPoints.map(({ id }, i) => (
-        <circle
-          key={id}
-          id={id}
+      {scaledPoints.map((point) => (
+        <Point
+          key={point.id}
           name={name}
-          ref={(element) => {
-            if (element) {
-              refs.current[i] = element;
-            }
-          }}
-          r={4}
-          fill={color}
-          stroke="#ffffff"
+          pointData={point}
+          radius={4}
+          color={color}
           transform={transform}
+          animation={animation}
         />
       ))}
     </>

--- a/src/renderer/graph/utils.ts
+++ b/src/renderer/graph/utils.ts
@@ -220,6 +220,7 @@ export const getTotalPoints = (
   const logEnd = Math.log10(GRAPH_END);
   const step = (logEnd - logStart) / NUM_STEPS;
 
+  // Get sampling frequencies for rendering the line
   const sampleFrequencies = range(logStart, logEnd + step, step).map(
     (p) => 10 ** p
   );
@@ -229,8 +230,10 @@ export const getTotalPoints = (
   });
 
   for (let i = 0; i < sampleFrequencies.length; i += 1) {
+    // Add fixed preamp gain for each sample point
     data[i].y = preAmp;
     for (let j = 0; j < filterLines.length; j += 1) {
+      // Add frequency gain obtained from each filter
       data[i].y += filterLines[j][i].y;
     }
   }
@@ -239,7 +242,8 @@ export const getTotalPoints = (
     return { x: f, y: 0, id: '' };
   });
 
-  for (let i = 0; i < freqPoints.length; i += 1) {
+  for (let i = 0; i < freqPoints[0].length; i += 1) {
+    // Add fixed preamp gain for each sample point
     points[i].id = freqPoints[0][i].id;
     points[i].y = preAmp;
     for (let j = 0; j < freqPoints.length; j += 1) {

--- a/src/renderer/graph/utils.ts
+++ b/src/renderer/graph/utils.ts
@@ -209,28 +209,3 @@ export const getCombinedLineData = (
 
   return data;
 };
-
-// Get total curve data points from state directly
-export const getDataPoints = (preAmp: number, filters: IFilter[]) => {
-  const tfs = filters.map((f) => getTFCoefficients(f));
-  const filterGains: number[][] = Array(tfs.length).fill(
-    Array(NUM_STEPS + 1).fill(0)
-  );
-  const totalGains: number[] = Array(NUM_STEPS + 1).fill(0);
-
-  const data: IChartPointData[] = SAMPLE_FREQUENCIES.map((f) => {
-    return { x: f, y: 0 };
-  });
-
-  for (let i = 0; i < SAMPLE_FREQUENCIES.length; i += 1) {
-    totalGains[i] = preAmp;
-    for (let j = 0; j < tfs.length; j += 1) {
-      const freqFilterGain = gainAtFrequency(SAMPLE_FREQUENCIES[i], tfs[j]);
-      filterGains[j][i] = freqFilterGain;
-      totalGains[i] += freqFilterGain;
-    }
-    data[i].y = totalGains[i];
-  }
-
-  return data;
-};

--- a/src/renderer/styles/color.ts
+++ b/src/renderer/styles/color.ts
@@ -1,0 +1,38 @@
+// Primary
+export enum PrimaryColorEnum {
+  DARK = '#1c313a',
+  DEFAULT = '#455a64',
+  LIGHT = '#718792',
+  LIGHTER = '#a0b7c2',
+}
+
+// Secondary
+export enum SecondaryColorEnum {
+  DARKER = 'linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)), #0093c4',
+  DARK = '#0093c4',
+  DEFAULT = '#4fc3f7',
+  LIGHT = '#8bf6ff',
+}
+
+export enum ColorEnum {
+  // Complementary
+  COMPLEMENTARY = '#f7844f',
+
+  // Triadic
+  TRIADIC1 = '#844ff7',
+  TRIADIC2 = '#f74fc2',
+
+  // Analogous
+  ANALOGOUS1 = '#4f6ef7',
+  ANALOGOUS2 = '#4ff7d8',
+}
+
+export enum GrayScaleEnum {
+  BLACK = '#000000',
+  WHITE = '#ffffff',
+}
+
+export const getColor = (index: number) => {
+  const colors = Object.values(ColorEnum);
+  return colors[index % colors.length];
+};

--- a/src/renderer/styles/color.ts
+++ b/src/renderer/styles/color.ts
@@ -36,3 +36,9 @@ export const getColor = (index: number) => {
   const colors = Object.values(ColorEnum);
   return colors[index % colors.length];
 };
+
+export type Color =
+  | PrimaryColorEnum
+  | SecondaryColorEnum
+  | ColorEnum
+  | GrayScaleEnum;

--- a/src/renderer/utils/utils.ts
+++ b/src/renderer/utils/utils.ts
@@ -106,3 +106,19 @@ export const usePrevious = <T>(value: T): T | undefined => {
 
   return prevChildrenRef.current;
 };
+
+export const useIsNotFirstRender = () => {
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isFirstRender.current = true;
+    };
+  }, []);
+
+  if (isFirstRender.current) {
+    isFirstRender.current = false;
+    return false;
+  }
+  return true;
+};

--- a/src/renderer/utils/utils.ts
+++ b/src/renderer/utils/utils.ts
@@ -106,19 +106,3 @@ export const usePrevious = <T>(value: T): T | undefined => {
 
   return prevChildrenRef.current;
 };
-
-export const useIsNotFirstRender = () => {
-  const isFirstRender = useRef(true);
-
-  useEffect(() => {
-    return () => {
-      isFirstRender.current = true;
-    };
-  }, []);
-
-  if (isFirstRender.current) {
-    isFirstRender.current = false;
-    return false;
-  }
-  return true;
-};

--- a/src/renderer/utils/utils.ts
+++ b/src/renderer/utils/utils.ts
@@ -106,3 +106,19 @@ export const usePrevious = <T>(value: T): T | undefined => {
 
   return prevChildrenRef.current;
 };
+
+export const useIsFirstRender = () => {
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isFirstRender.current = true;
+    };
+  }, []);
+
+  if (isFirstRender.current) {
+    isFirstRender.current = false;
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
# Summary
This PR adds additional curves representing the gain adjustments introduced by each filter as well as its corresponding control point. The points (and curves) adjust accordingly when filters are updated.

## Changes
- add `Point` component for rendering a set of points at the correct location using d3
- add a `Curve` component for rendering a line and a corresponding control point
   - refactor chartData to store `Curve` data (line and point)
- add code to compute the coordinates of these points based on the filter frequency
- added a helper hook `useIsNotFirstRender` for cleaning up animations
- fix and improve animations for the graph
- add color enums for use in `.tsx` files

<img width="767" alt="image" src="https://user-images.githubusercontent.com/30204513/214453884-f2938056-2d66-4991-92d9-b9182fcbcbda.png">
