### PR TITLE
JAT-89 Edit preset names

### DIFF
--- a/src/__tests__/unit_tests/PresetListItem.test.tsx
+++ b/src/__tests__/unit_tests/PresetListItem.test.tsx
@@ -101,8 +101,8 @@ describe('PresetListItem', () => {
 
   it('should handle change with format change', async () => {
     const testValue = 'Standard';
-    const newValue = 'tO pRoPeR cAsInG';
-    const expectedNewValue = 'To proper casing';
+    const newValue = 'tO p$RoPeR /cAsInG -_';
+    const expectedNewValue = 'To proper casing -_';
     const { user } = setup(
       <PresetListItem
         value={testValue}

--- a/src/__tests__/unit_tests/PresetListItem.test.tsx
+++ b/src/__tests__/unit_tests/PresetListItem.test.tsx
@@ -7,12 +7,12 @@ describe('PresetListItem', () => {
   const editModeLabel = 'Edit Preset Name';
   const editIconLabel = 'Edit Icon';
   const deleteIconLabel = 'Delete Icon';
-  const handleChange = jest.fn();
+  const handleRename = jest.fn();
   const handleDelete = jest.fn();
   const validate = jest.fn();
 
   beforeEach(() => {
-    handleChange.mockClear();
+    handleRename.mockClear();
     handleDelete.mockClear();
     validate.mockClear();
   });
@@ -22,7 +22,7 @@ describe('PresetListItem', () => {
     setup(
       <PresetListItem
         value={testValue}
-        handleChange={handleChange}
+        handleRename={handleRename}
         handleDelete={handleDelete}
         isDisabled={false}
         validate={validate}
@@ -39,7 +39,7 @@ describe('PresetListItem', () => {
     const { user } = setup(
       <PresetListItem
         value={testValue}
-        handleChange={handleChange}
+        handleRename={handleRename}
         handleDelete={handleDelete}
         isDisabled={false}
         validate={validate}
@@ -61,7 +61,7 @@ describe('PresetListItem', () => {
     const { user } = setup(
       <PresetListItem
         value={testValue}
-        handleChange={handleChange}
+        handleRename={handleRename}
         handleDelete={handleDelete}
         isDisabled={false}
         validate={validate}
@@ -79,7 +79,7 @@ describe('PresetListItem', () => {
     const { user } = setup(
       <PresetListItem
         value={testValue}
-        handleChange={handleChange}
+        handleRename={handleRename}
         handleDelete={handleDelete}
         isDisabled={false}
         validate={validate}
@@ -95,8 +95,8 @@ describe('PresetListItem', () => {
     await user.keyboard('{Enter}');
     expect(screen.getByLabelText(editIconLabel)).toBeInTheDocument();
     expect(validate).toHaveBeenCalledTimes(1);
-    expect(handleChange).toHaveBeenCalledTimes(1);
-    expect(handleChange).toHaveBeenCalledWith(newValue);
+    expect(handleRename).toHaveBeenCalledTimes(1);
+    expect(handleRename).toHaveBeenCalledWith(newValue);
   });
 
   it('should handle change with format change', async () => {
@@ -106,7 +106,7 @@ describe('PresetListItem', () => {
     const { user } = setup(
       <PresetListItem
         value={testValue}
-        handleChange={handleChange}
+        handleRename={handleRename}
         handleDelete={handleDelete}
         isDisabled={false}
         validate={validate}
@@ -122,8 +122,8 @@ describe('PresetListItem', () => {
     await user.keyboard('{Enter}');
     expect(screen.getByLabelText(editIconLabel)).toBeInTheDocument();
     expect(validate).toHaveBeenCalledTimes(1);
-    expect(handleChange).toHaveBeenCalledTimes(1);
-    expect(handleChange).toHaveBeenCalledWith(expectedNewValue);
+    expect(handleRename).toHaveBeenCalledTimes(1);
+    expect(handleRename).toHaveBeenCalledWith(expectedNewValue);
   });
 
   it('should handle change with validation error', async () => {
@@ -135,7 +135,7 @@ describe('PresetListItem', () => {
     const { user } = setup(
       <PresetListItem
         value={testValue}
-        handleChange={handleChange}
+        handleRename={handleRename}
         handleDelete={handleDelete}
         isDisabled={false}
         validate={validate}
@@ -151,7 +151,7 @@ describe('PresetListItem', () => {
     await user.keyboard('{Enter}');
 
     expect(validate).toHaveBeenCalledTimes(1);
-    expect(handleChange).toHaveBeenCalledTimes(0);
+    expect(handleRename).toHaveBeenCalledTimes(0);
     expect(screen.queryByLabelText(editIconLabel)).not.toBeInTheDocument();
     expect(screen.getByText(errorMsg)).toBeInTheDocument();
   });
@@ -162,7 +162,7 @@ describe('PresetListItem', () => {
     setup(
       <PresetListItem
         value={testValue}
-        handleChange={handleChange}
+        handleRename={handleRename}
         handleDelete={handleDelete}
         isDisabled
         validate={validate}

--- a/src/__tests__/unit_tests/PresetListItem.test.tsx
+++ b/src/__tests__/unit_tests/PresetListItem.test.tsx
@@ -1,0 +1,176 @@
+import '@testing-library/jest-dom';
+import { screen } from '@testing-library/react';
+import { clearAndType, setup } from '__tests__/utils/userEventUtils';
+import PresetListItem from '../../renderer/components/PresetListItem';
+
+describe('PresetListItem', () => {
+  const editModeLabel = 'Edit Preset Name';
+  const editIconLabel = 'Edit Icon';
+  const deleteIconLabel = 'Delete Icon';
+  const handleChange = jest.fn();
+  const handleDelete = jest.fn();
+  const validate = jest.fn();
+
+  beforeEach(() => {
+    handleChange.mockClear();
+    handleDelete.mockClear();
+    validate.mockClear();
+  });
+
+  it('should render display mode', async () => {
+    const testValue = 'Standard';
+    setup(
+      <PresetListItem
+        value={testValue}
+        handleChange={handleChange}
+        handleDelete={handleDelete}
+        isDisabled={false}
+        validate={validate}
+      />
+    );
+
+    expect(screen.getByText(testValue)).toBeInTheDocument();
+    expect(screen.getByLabelText(editIconLabel)).toBeInTheDocument();
+    expect(screen.getByLabelText(deleteIconLabel)).toBeInTheDocument();
+  });
+
+  it('should enter and exit edit mode', async () => {
+    const testValue = 'Standard';
+    const { user } = setup(
+      <PresetListItem
+        value={testValue}
+        handleChange={handleChange}
+        handleDelete={handleDelete}
+        isDisabled={false}
+        validate={validate}
+      />
+    );
+    const editIcon = screen.getByLabelText(editIconLabel);
+    await user.click(editIcon);
+
+    const editInput = screen.getByLabelText(editModeLabel);
+    expect(editInput).toBeInTheDocument();
+
+    await user.click(editInput);
+    await user.keyboard('{Escape}');
+    expect(screen.getByLabelText(editIconLabel)).toBeInTheDocument();
+  });
+
+  it('should handle delete', async () => {
+    const testValue = 'Standard';
+    const { user } = setup(
+      <PresetListItem
+        value={testValue}
+        handleChange={handleChange}
+        handleDelete={handleDelete}
+        isDisabled={false}
+        validate={validate}
+      />
+    );
+    const deleteIcon = screen.getByLabelText(deleteIconLabel);
+    await user.click(deleteIcon);
+
+    expect(handleDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle change', async () => {
+    const testValue = 'Standard';
+    const newValue = 'Standard 2';
+    const { user } = setup(
+      <PresetListItem
+        value={testValue}
+        handleChange={handleChange}
+        handleDelete={handleDelete}
+        isDisabled={false}
+        validate={validate}
+      />
+    );
+    const editIcon = screen.getByLabelText(editIconLabel);
+    await user.click(editIcon);
+
+    const editInput = screen.getByLabelText(editModeLabel);
+    expect(editInput).toBeInTheDocument();
+
+    await clearAndType(user, editInput, newValue);
+    await user.keyboard('{Enter}');
+    expect(screen.getByLabelText(editIconLabel)).toBeInTheDocument();
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith(newValue);
+  });
+
+  it('should handle change with format change', async () => {
+    const testValue = 'Standard';
+    const newValue = 'tO pRoPeR cAsInG';
+    const expectedNewValue = 'To proper casing';
+    const { user } = setup(
+      <PresetListItem
+        value={testValue}
+        handleChange={handleChange}
+        handleDelete={handleDelete}
+        isDisabled={false}
+        validate={validate}
+      />
+    );
+    const editIcon = screen.getByLabelText(editIconLabel);
+    await user.click(editIcon);
+
+    const editInput = screen.getByLabelText(editModeLabel);
+    expect(editInput).toBeInTheDocument();
+
+    await clearAndType(user, editInput, newValue);
+    await user.keyboard('{Enter}');
+    expect(screen.getByLabelText(editIconLabel)).toBeInTheDocument();
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith(expectedNewValue);
+  });
+
+  it('should handle change with validation error', async () => {
+    const testValue = 'Standard';
+    const newValue = 'Temp';
+    const errorMsg = 'ERROR';
+    validate.mockReturnValue(errorMsg);
+
+    const { user } = setup(
+      <PresetListItem
+        value={testValue}
+        handleChange={handleChange}
+        handleDelete={handleDelete}
+        isDisabled={false}
+        validate={validate}
+      />
+    );
+    const editIcon = screen.getByLabelText(editIconLabel);
+    await user.click(editIcon);
+
+    const editInput = screen.getByLabelText(editModeLabel);
+    expect(editInput).toBeInTheDocument();
+
+    await clearAndType(user, editInput, newValue);
+    await user.keyboard('{Enter}');
+
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledTimes(0);
+    expect(screen.queryByLabelText(editIconLabel)).not.toBeInTheDocument();
+    expect(screen.getByText(errorMsg)).toBeInTheDocument();
+  });
+
+  it('should be disabled', async () => {
+    const testValue = 'Standard';
+
+    setup(
+      <PresetListItem
+        value={testValue}
+        handleChange={handleChange}
+        handleDelete={handleDelete}
+        isDisabled
+        validate={validate}
+      />
+    );
+    const editIcon = screen.getByLabelText(editIconLabel);
+    expect(editIcon).toHaveAttribute('aria-disabled', 'true');
+    const deleteIcon = screen.getByLabelText(editIconLabel);
+    expect(deleteIcon).toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/src/__tests__/unit_tests/TextInput.test.tsx
+++ b/src/__tests__/unit_tests/TextInput.test.tsx
@@ -24,6 +24,7 @@ describe('TextInput', () => {
         handleChange={handleChange}
         handleEscape={handleEscape}
         isDisabled={false}
+        errorMessage=""
       />
     );
 
@@ -45,6 +46,7 @@ describe('TextInput', () => {
         handleChange={handleChange}
         handleEscape={handleEscape}
         isDisabled={false}
+        errorMessage=""
         updateOnSubmitOnly
       />
     );
@@ -59,104 +61,23 @@ describe('TextInput', () => {
     expect(handleChange).toHaveBeenCalledTimes(1);
   });
 
-  it('should handle change with validation', async () => {
-    const testValue = 'Standard';
-    const { user } = setup(
-      <TextInput
-        value={testValue}
-        ariaLabel={name}
-        handleChange={handleChange}
-        handleEscape={handleEscape}
-        validate={validate}
-        isDisabled={false}
-      />
-    );
-
-    const editInput = screen.getByLabelText(name);
-    expect(editInput).toHaveValue(testValue);
-
-    await user.type(editInput, 'ab');
-    expect(validate).toHaveBeenCalledTimes(2);
-    expect(handleChange).toHaveBeenCalledTimes(2);
-    await user.keyboard('{Enter}');
-    expect(validate).toHaveBeenCalledTimes(2);
-    expect(handleChange).toHaveBeenCalledTimes(2);
-  });
-
-  it('should handle change with validation on submit only', async () => {
-    const testValue = 'Standard';
-    const { user } = setup(
-      <TextInput
-        value={testValue}
-        ariaLabel={name}
-        handleChange={handleChange}
-        handleEscape={handleEscape}
-        isDisabled={false}
-        validate={validate}
-        updateOnSubmitOnly
-      />
-    );
-
-    const editInput = screen.getByLabelText(name);
-    expect(editInput).toHaveValue(testValue);
-
-    await user.type(editInput, 'ab');
-    expect(validate).toHaveBeenCalledTimes(0);
-    expect(handleChange).toHaveBeenCalledTimes(0);
-
-    await user.keyboard('{Enter}');
-    expect(validate).toHaveBeenCalledTimes(1);
-    expect(handleChange).toHaveBeenCalledTimes(1);
-  });
-
-  it('should handle failed validation', async () => {
+  it('should display error message', async () => {
     const testValue = 'Standard';
     const errorMsg = 'ERROR';
     validate.mockReturnValue(errorMsg);
-    const { user } = setup(
+    setup(
       <TextInput
         value={testValue}
         ariaLabel={name}
         handleChange={handleChange}
         handleEscape={handleEscape}
         isDisabled={false}
-        validate={validate}
+        errorMessage={errorMsg}
       />
     );
 
     const editInput = screen.getByLabelText(name);
     expect(editInput).toHaveValue(testValue);
-
-    await user.type(editInput, 'ab');
-    expect(validate).toHaveBeenCalledTimes(2);
-    expect(handleChange).toHaveBeenCalledTimes(0);
-    expect(screen.getByText(errorMsg)).toBeInTheDocument();
-  });
-
-  it('should handle failed validation on submit only', async () => {
-    const testValue = 'Standard';
-    const errorMsg = 'ERROR';
-    validate.mockReturnValue(errorMsg);
-    const { user } = setup(
-      <TextInput
-        value={testValue}
-        ariaLabel={name}
-        handleChange={handleChange}
-        handleEscape={handleEscape}
-        isDisabled={false}
-        validate={validate}
-        updateOnSubmitOnly
-      />
-    );
-
-    const editInput = screen.getByLabelText(name);
-    expect(editInput).toHaveValue(testValue);
-
-    await user.type(editInput, 'ab');
-    expect(validate).toHaveBeenCalledTimes(0);
-    await user.keyboard('{Enter}');
-    expect(validate).toHaveBeenCalledTimes(1);
-    expect(handleChange).toHaveBeenCalledTimes(0);
     expect(screen.getByText(errorMsg)).toBeInTheDocument();
   });
 
@@ -169,7 +90,7 @@ describe('TextInput', () => {
         handleChange={handleChange}
         handleEscape={handleEscape}
         isDisabled
-        validate={validate}
+        errorMessage=""
       />
     );
 

--- a/src/__tests__/unit_tests/TextInput.test.tsx
+++ b/src/__tests__/unit_tests/TextInput.test.tsx
@@ -1,0 +1,181 @@
+import '@testing-library/jest-dom';
+import { screen } from '@testing-library/react';
+import { setup } from '__tests__/utils/userEventUtils';
+import TextInput from '../../renderer/widgets/TextInput';
+
+describe('TextInput', () => {
+  const name = 'Text Input';
+  const handleChange = jest.fn();
+  const handleEscape = jest.fn();
+  const validate = jest.fn();
+
+  beforeEach(() => {
+    handleChange.mockClear();
+    handleEscape.mockClear();
+    validate.mockClear();
+  });
+
+  it('should handle change', async () => {
+    const testValue = 'Standard';
+    const { user } = setup(
+      <TextInput
+        value={testValue}
+        ariaLabel={name}
+        handleChange={handleChange}
+        handleEscape={handleEscape}
+        isDisabled={false}
+      />
+    );
+
+    const editInput = screen.getByLabelText(name);
+    expect(editInput).toHaveValue(testValue);
+
+    await user.type(editInput, 'ab');
+    expect(handleChange).toHaveBeenCalledTimes(2);
+    await user.keyboard('{Enter}');
+    expect(handleChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle change on submit only', async () => {
+    const testValue = 'Standard';
+    const { user } = setup(
+      <TextInput
+        value={testValue}
+        ariaLabel={name}
+        handleChange={handleChange}
+        handleEscape={handleEscape}
+        isDisabled={false}
+        updateOnSubmitOnly
+      />
+    );
+
+    const editInput = screen.getByLabelText(name);
+    expect(editInput).toHaveValue(testValue);
+
+    await user.type(editInput, 'ab');
+    expect(handleChange).toHaveBeenCalledTimes(0);
+
+    await user.keyboard('{Enter}');
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle change with validation', async () => {
+    const testValue = 'Standard';
+    const { user } = setup(
+      <TextInput
+        value={testValue}
+        ariaLabel={name}
+        handleChange={handleChange}
+        handleEscape={handleEscape}
+        validate={validate}
+        isDisabled={false}
+      />
+    );
+
+    const editInput = screen.getByLabelText(name);
+    expect(editInput).toHaveValue(testValue);
+
+    await user.type(editInput, 'ab');
+    expect(validate).toHaveBeenCalledTimes(2);
+    expect(handleChange).toHaveBeenCalledTimes(2);
+    await user.keyboard('{Enter}');
+    expect(validate).toHaveBeenCalledTimes(2);
+    expect(handleChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle change with validation on submit only', async () => {
+    const testValue = 'Standard';
+    const { user } = setup(
+      <TextInput
+        value={testValue}
+        ariaLabel={name}
+        handleChange={handleChange}
+        handleEscape={handleEscape}
+        isDisabled={false}
+        validate={validate}
+        updateOnSubmitOnly
+      />
+    );
+
+    const editInput = screen.getByLabelText(name);
+    expect(editInput).toHaveValue(testValue);
+
+    await user.type(editInput, 'ab');
+    expect(validate).toHaveBeenCalledTimes(0);
+    expect(handleChange).toHaveBeenCalledTimes(0);
+
+    await user.keyboard('{Enter}');
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle failed validation', async () => {
+    const testValue = 'Standard';
+    const errorMsg = 'ERROR';
+    validate.mockReturnValue(errorMsg);
+    const { user } = setup(
+      <TextInput
+        value={testValue}
+        ariaLabel={name}
+        handleChange={handleChange}
+        handleEscape={handleEscape}
+        isDisabled={false}
+        validate={validate}
+      />
+    );
+
+    const editInput = screen.getByLabelText(name);
+    expect(editInput).toHaveValue(testValue);
+
+    await user.type(editInput, 'ab');
+    expect(validate).toHaveBeenCalledTimes(2);
+    expect(handleChange).toHaveBeenCalledTimes(0);
+    expect(screen.getByText(errorMsg)).toBeInTheDocument();
+  });
+
+  it('should handle failed validation on submit only', async () => {
+    const testValue = 'Standard';
+    const errorMsg = 'ERROR';
+    validate.mockReturnValue(errorMsg);
+    const { user } = setup(
+      <TextInput
+        value={testValue}
+        ariaLabel={name}
+        handleChange={handleChange}
+        handleEscape={handleEscape}
+        isDisabled={false}
+        validate={validate}
+        updateOnSubmitOnly
+      />
+    );
+
+    const editInput = screen.getByLabelText(name);
+    expect(editInput).toHaveValue(testValue);
+
+    await user.type(editInput, 'ab');
+    expect(validate).toHaveBeenCalledTimes(0);
+    await user.keyboard('{Enter}');
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledTimes(0);
+    expect(screen.getByText(errorMsg)).toBeInTheDocument();
+  });
+
+  it('should be disabled', async () => {
+    const testValue = 'Standard';
+    setup(
+      <TextInput
+        value={testValue}
+        ariaLabel={name}
+        handleChange={handleChange}
+        handleEscape={handleEscape}
+        isDisabled
+        validate={validate}
+      />
+    );
+
+    expect(screen.getByLabelText(name)).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+});

--- a/src/common/channels.ts
+++ b/src/common/channels.ts
@@ -22,6 +22,7 @@ enum ChannelEnum {
   LOAD_PRESET = 'loadPreset',
   SAVE_PRESET = 'savePreset',
   DELETE_PRESET = 'deletePreset',
+  RENAME_PRESET = 'renamePreset',
   GET_PRESET_FILE_LIST = 'getPresetFileList',
 }
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -104,3 +104,30 @@ export const getDefaultState = (): IState => {
     filters: getDefaultFilters(),
   };
 };
+
+export const RESERVED_FILE_NAMES_SET = new Set([
+  'CON',
+  'PRN',
+  'AUX',
+  'NUL',
+  'COM1',
+  'COM2',
+  'COM3',
+  'COM4',
+  'COM5',
+  'COM6',
+  'COM7',
+  'COM8',
+  'COM9',
+  'COM0',
+  'LPT1',
+  'LPT2',
+  'LPT3',
+  'LPT4',
+  'LPT5',
+  'LPT6',
+  'LPT7',
+  'LPT8',
+  'LPT9',
+  'LPT0',
+]);

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -5,6 +5,7 @@ export enum ErrorCode {
   INVALID_PARAMETER,
   FAILURE,
   PRESET_FILE_ERROR,
+  INVALID_PRESET_NAME,
 }
 
 export type ErrorDescription = {
@@ -47,6 +48,12 @@ export const errors: Record<ErrorCode, ErrorDescription> = {
     action:
       'Please check that the preset name is saveable as a file and that the installation directory is in a writeable place. In addition, check that you have available storage space. If the error persists, try reaching out to the developers to resolve the issue.',
     code: ErrorCode.PRESET_FILE_ERROR,
+  },
+  [ErrorCode.INVALID_PRESET_NAME]: {
+    shortError: 'Internal Error: Invalid preset name provided.',
+    action:
+      'Please provide a different preset name. If the error persists, try reaching out to the developers to resolve the issue.',
+    code: ErrorCode.INVALID_PRESET_NAME,
   },
 };
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,4 +1,9 @@
-import { IFilter, MAX_FREQUENCY, MIN_FREQUENCY } from './constants';
+import {
+  IFilter,
+  MAX_FREQUENCY,
+  MIN_FREQUENCY,
+  RESERVED_FILE_NAMES_SET,
+} from './constants';
 
 export const roundToPrecision = (value: number, precision: number) => {
   const precisionFactor = 10 ** precision;
@@ -12,3 +17,14 @@ export const computeAvgFreq = (filters: IFilter[], index: number) => {
   const exponent = (Math.log10(lo) + Math.log10(hi)) / 2;
   return roundToPrecision(10 ** exponent, 0);
 };
+
+export const isRestrictedPresetName = (newName: string) =>
+  RESERVED_FILE_NAMES_SET.has(newName.toUpperCase());
+
+export const isDuplicatePresetName = (
+  newName: string,
+  existingNames: string[]
+) =>
+  existingNames.some(
+    (oldValue) => newName.toLowerCase() === oldValue.toLowerCase()
+  );

--- a/src/main/flush.ts
+++ b/src/main/flush.ts
@@ -100,6 +100,16 @@ export const savePreset = (presetName: string, preset_info: IPreset) => {
   console.log(`Wrote preset for: ${presetName}`);
 };
 
+export const doesPresetExist = (presetName: string) => {
+  const testPath = addFileToPath(PRESETS_DIR, presetName);
+  try {
+    return fs.existsSync(testPath);
+  } catch (ex) {
+    console.log('Failed to check whether preset %d exists', presetName);
+    throw ex;
+  }
+};
+
 export const renamePreset = (oldName: string, newName: string) => {
   const oldPath = addFileToPath(PRESETS_DIR, oldName);
   const newPath = addFileToPath(PRESETS_DIR, newName);

--- a/src/main/flush.ts
+++ b/src/main/flush.ts
@@ -100,6 +100,17 @@ export const savePreset = (presetName: string, preset_info: IPreset) => {
   console.log(`Wrote preset for: ${presetName}`);
 };
 
+export const renamePreset = (oldName: string, newName: string) => {
+  const oldPath = addFileToPath(PRESETS_DIR, oldName);
+  const newPath = addFileToPath(PRESETS_DIR, newName);
+  try {
+    fs.renameSync(oldPath, newPath);
+  } catch (ex) {
+    console.log('Failed to rename preset %d to preset %d', oldName, newName);
+    throw ex;
+  }
+};
+
 export const flush = (state: IState, configDirPath: string) => {
   const configPath = addFileToPath(configDirPath, AQUA_CONFIG_FILENAME);
   try {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -549,6 +549,7 @@ const createMainWindow = async () => {
     minHeight: WINDOW_HEIGHT,
     maxHeight: WINDOW_HEIGHT,
     icon: getAssetPath('icon.png'),
+    resizable: false,
     webPreferences: {
       preload: app.isPackaged
         ? path.join(__dirname, 'preload.js')

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -22,6 +22,7 @@ import {
   updateConfig,
   savePreset,
   fetchPreset,
+  renamePreset,
 } from './flush';
 import MenuBuilder from './menu';
 import { resolveHtmlPath } from './util';
@@ -224,6 +225,13 @@ ipcMain.on(ChannelEnum.DELETE_PRESET, async (event, arg) => {
     console.log(e);
     handleError(event, channel, ErrorCode.PRESET_FILE_ERROR);
   }
+});
+
+ipcMain.on(ChannelEnum.RENAME_PRESET, async (event, arg) => {
+  const channel = ChannelEnum.RENAME_PRESET;
+  const [oldName, newName]: string[] = arg;
+  renamePreset(oldName, newName);
+  await handleUpdate(event, channel);
 });
 
 ipcMain.on(ChannelEnum.GET_PRESET_FILE_LIST, async (event) => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -230,8 +230,12 @@ ipcMain.on(ChannelEnum.DELETE_PRESET, async (event, arg) => {
 ipcMain.on(ChannelEnum.RENAME_PRESET, async (event, arg) => {
   const channel = ChannelEnum.RENAME_PRESET;
   const [oldName, newName]: string[] = arg;
-  renamePreset(oldName, newName);
-  await handleUpdate(event, channel);
+  try {
+    renamePreset(oldName, newName);
+    await handleUpdate(event, channel);
+  } catch (e) {
+    handleError(event, channel, ErrorCode.PRESET_FILE_ERROR);
+  }
 });
 
 ipcMain.on(ChannelEnum.GET_PRESET_FILE_LIST, async (event) => {

--- a/src/renderer/PresetsBar.tsx
+++ b/src/renderer/PresetsBar.tsx
@@ -5,6 +5,7 @@ import {
   deletePreset,
   getPresetListFromFiles,
   loadPreset,
+  renamePreset,
   savePreset,
 } from './utils/equalizerApi';
 import { useAquaContext } from './utils/AquaContext';
@@ -98,14 +99,18 @@ const PresetsBar = () => {
 
   // Renaming an existing preset
   const handleEditExistingPresetName = useCallback(
-    (oldValue: string) => (newValue: string) => {
-      // TODO: improve DS to help check if the newValue is an existing preset or not
-      setPresetNames(
-        // Keep presets sorted
-        presetNames.map((n) => (n === oldValue ? newValue : n)).sort()
-      );
+    (oldValue: string) => async (newValue: string) => {
+      try {
+        await renamePreset(oldValue, newValue);
+        setPresetNames(
+          // Keep presets sorted
+          presetNames.map((n) => (n === oldValue ? newValue : n)).sort()
+        );
+      } catch (e) {
+        setGlobalError(e as ErrorDescription);
+      }
     },
-    [presetNames]
+    [presetNames, setGlobalError]
   );
 
   // Validating a new preset name

--- a/src/renderer/PresetsBar.tsx
+++ b/src/renderer/PresetsBar.tsx
@@ -13,7 +13,8 @@ import { useAquaContext } from './utils/AquaContext';
 import TextInput from './widgets/TextInput';
 import Button from './widgets/Button';
 import List, { IOptionEntry } from './widgets/List';
-import PresetListItem, { formatPresetName } from './components/PresetListItem';
+import PresetListItem from './components/PresetListItem';
+import { formatPresetName } from './utils/utils';
 
 enum PresetErrorEnum {
   EMPTY = 'Preset name cannot be empty.',
@@ -28,7 +29,7 @@ const PresetsBar = () => {
   const [selectedPresetName, setSelectedPresetName] = useState<
     string | undefined
   >(undefined);
-  const [presetNameError, setPresetNameError] = useState<string>('');
+  const [newPresetNameError, setNewPresetNameError] = useState<string>('');
   const [presetNames, setPresetNames] = useState<string[]>([]);
 
   // Fetch default presets and custom presets from storage
@@ -110,7 +111,7 @@ const PresetsBar = () => {
 
     // Validate new preset name and update error message accordingly
     const msg = validatePresetName(newValue);
-    setPresetNameError(msg);
+    setNewPresetNameError(msg);
   };
 
   // Changing the selected preset in the UI
@@ -181,7 +182,7 @@ const PresetsBar = () => {
           value={presetName}
           ariaLabel="Preset Name"
           isDisabled={!!globalError}
-          errorMessage={presetNameError}
+          errorMessage={newPresetNameError}
           handleChange={handleChangeNewPresetName}
           formatInput={formatPresetName}
         />
@@ -189,7 +190,7 @@ const PresetsBar = () => {
       <Button
         ariaLabel="Save settings to preset"
         className="small"
-        isDisabled={!!globalError || !presetName || !!presetNameError}
+        isDisabled={!!globalError || !presetName || !!newPresetNameError}
         handleChange={() => handleCreatePreset(presetNames)}
       >
         Save current settings to preset

--- a/src/renderer/PresetsBar.tsx
+++ b/src/renderer/PresetsBar.tsx
@@ -117,7 +117,7 @@ const PresetsBar = () => {
   const validatePresetName = useCallback(
     (newValue: string) => {
       if (!newValue) {
-        return 'Preset name cannot be emtpy.';
+        return 'Preset name cannot be empty.';
       }
       if (
         presetNames.some(

--- a/src/renderer/PresetsBar.tsx
+++ b/src/renderer/PresetsBar.tsx
@@ -116,6 +116,9 @@ const PresetsBar = () => {
   // Validating a new preset name
   const validatePresetName = useCallback(
     (newValue: string) => {
+      if (!newValue) {
+        return 'Preset name cannot be emtpy.';
+      }
       if (
         presetNames.some(
           (oldValue) => newValue.toLowerCase() === oldValue.toLowerCase()

--- a/src/renderer/PresetsBar.tsx
+++ b/src/renderer/PresetsBar.tsx
@@ -14,6 +14,33 @@ import Button from './widgets/Button';
 import List, { IOptionEntry } from './widgets/List';
 import PresetListItem, { formatPresetName } from './components/PresetListItem';
 
+const RESERVED_FILE_NAMES_SET = new Set([
+  'CON',
+  'PRN',
+  'AUX',
+  'NUL',
+  'COM1',
+  'COM2',
+  'COM3',
+  'COM4',
+  'COM5',
+  'COM6',
+  'COM7',
+  'COM8',
+  'COM9',
+  'COM0',
+  'LPT1',
+  'LPT2',
+  'LPT3',
+  'LPT4',
+  'LPT5',
+  'LPT6',
+  'LPT7',
+  'LPT8',
+  'LPT9',
+  'LPT0',
+]);
+
 const PresetsBar = () => {
   const { globalError, performHealthCheck, setGlobalError } = useAquaContext();
 
@@ -114,7 +141,16 @@ const PresetsBar = () => {
   );
 
   // Validating a new preset name
-  const validatePresetName = useCallback(
+  const validatePresetName = useCallback((newValue: string) => {
+    if (RESERVED_FILE_NAMES_SET.has(newValue.toUpperCase())) {
+      return 'Invalid preset name, please use another.';
+    }
+
+    return undefined;
+  }, []);
+
+  // Validating a preset rename
+  const validatePresetRename = useCallback(
     (newValue: string) => {
       if (!newValue) {
         return 'Preset name cannot be empty.';
@@ -127,9 +163,9 @@ const PresetsBar = () => {
         return 'Duplicate name found.';
       }
 
-      return undefined;
+      return validatePresetName(newValue);
     },
-    [presetNames]
+    [validatePresetName, presetNames]
   );
 
   const options: IOptionEntry[] = useMemo(() => {
@@ -143,13 +179,13 @@ const PresetsBar = () => {
             handleChange={handleRenameExistingPresetName(n)}
             handleDelete={handleDeletePreset(n)}
             isDisabled={!!globalError}
-            validate={validatePresetName}
+            validate={validatePresetRename}
           />
         ),
       };
     });
   }, [
-    validatePresetName,
+    validatePresetRename,
     globalError,
     handleDeletePreset,
     handleRenameExistingPresetName,
@@ -159,14 +195,15 @@ const PresetsBar = () => {
   return (
     <div className="presets-bar">
       <h4>Preset Menu</h4>
-      <div className="row center preset-name">
-        Name:&nbsp;
+      <div className="row">
+        <div className="preset-name">Name:&nbsp;</div>
         <TextInput
           value={presetName}
           ariaLabel="Preset Name"
           isDisabled={!!globalError}
           handleChange={handleChangeNewPresetName}
           formatInput={formatPresetName}
+          validate={validatePresetName}
         />
       </div>
       <Button

--- a/src/renderer/PresetsBar.tsx
+++ b/src/renderer/PresetsBar.tsx
@@ -189,6 +189,10 @@ const PresetsBar = () => {
           oldName,
           newName,
         });
+
+        // Update selected preset and new preset name to reflect updated value
+        setPresetName(newName);
+        setSelectedPresetName(newName);
       } catch (e) {
         setGlobalError(e as ErrorDescription);
       }

--- a/src/renderer/PresetsBar.tsx
+++ b/src/renderer/PresetsBar.tsx
@@ -12,7 +12,7 @@ import TextInput from './widgets/TextInput';
 import Button from './widgets/Button';
 import List, { IOptionEntry } from './widgets/List';
 import IconButton, { IconName } from './widgets/IconButton';
-import { useClickOutside, useFocusOut } from './utils/utils';
+import { useMouseDownOutside } from './utils/utils';
 
 interface IListItemProps {
   value: string;
@@ -31,12 +31,7 @@ const PresetListItem = ({
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
 
   // Close edit mode if the user clicks outside of the input
-  useClickOutside<HTMLInputElement>(editValueRef, () => {
-    setIsEditMode(false);
-  });
-
-  // Close edit mode if the user tabs outside of the input
-  useFocusOut<HTMLInputElement>(editValueRef, () => {
+  useMouseDownOutside<HTMLInputElement>(editValueRef, () => {
     setIsEditMode(false);
   });
 
@@ -162,7 +157,6 @@ const PresetsBar = () => {
       oldValue: string,
       newValue: string
     ) => {
-      // TODO: Handle case where the new name already exists
       // TODO: improve DS to help check if the newValue is an existing preset or not
       setPresetNames(
         // Keep presets sorted
@@ -211,7 +205,7 @@ const PresetsBar = () => {
       </div>
       <Button
         ariaLabel="Save settings to preset"
-        className="small full"
+        className="small"
         isDisabled={!!globalError || !presetName}
         handleChange={() => handleCreatePreset(presetNames)}
       >
@@ -220,7 +214,6 @@ const PresetsBar = () => {
       <List
         name="preset"
         options={options}
-        className="full"
         itemClassName="preset-list-item"
         value={presetName}
         handleChange={handleChangeSelectedPreset}
@@ -228,7 +221,7 @@ const PresetsBar = () => {
       />
       <Button
         ariaLabel="Load selected preset"
-        className="small full"
+        className="small"
         isDisabled={!!globalError || !selectedPresetName}
         handleChange={handleLoadPreset}
       >

--- a/src/renderer/PresetsBar.tsx
+++ b/src/renderer/PresetsBar.tsx
@@ -12,7 +12,7 @@ import { useAquaContext } from './utils/AquaContext';
 import TextInput from './widgets/TextInput';
 import Button from './widgets/Button';
 import List, { IOptionEntry } from './widgets/List';
-import PresetListItem from './components/PresetListItem';
+import PresetListItem, { formatPresetName } from './components/PresetListItem';
 
 const PresetsBar = () => {
   const { globalError, performHealthCheck, setGlobalError } = useAquaContext();
@@ -166,6 +166,7 @@ const PresetsBar = () => {
           ariaLabel="Preset Name"
           isDisabled={!!globalError}
           handleChange={handleChangeNewPresetName}
+          formatInput={formatPresetName}
         />
       </div>
       <Button

--- a/src/renderer/PresetsBar.tsx
+++ b/src/renderer/PresetsBar.tsx
@@ -98,7 +98,7 @@ const PresetsBar = () => {
   );
 
   // Renaming an existing preset
-  const handleEditExistingPresetName = useCallback(
+  const handleRenameExistingPresetName = useCallback(
     (oldValue: string) => async (newValue: string) => {
       try {
         await renamePreset(oldValue, newValue);
@@ -137,7 +137,7 @@ const PresetsBar = () => {
         display: (
           <PresetListItem
             value={n}
-            handleChange={handleEditExistingPresetName(n)}
+            handleChange={handleRenameExistingPresetName(n)}
             handleDelete={handleDeletePreset(n)}
             isDisabled={!!globalError}
             validate={validatePresetName}
@@ -149,7 +149,7 @@ const PresetsBar = () => {
     validatePresetName,
     globalError,
     handleDeletePreset,
-    handleEditExistingPresetName,
+    handleRenameExistingPresetName,
     presetNames,
   ]);
 

--- a/src/renderer/components/PresetListItem.tsx
+++ b/src/renderer/components/PresetListItem.tsx
@@ -3,7 +3,7 @@ import { useMouseDownOutside } from 'renderer/utils/utils';
 import IconButton, { IconName } from 'renderer/widgets/IconButton';
 import TextInput from 'renderer/widgets/TextInput';
 
-const formatPresetName = (s: string) =>
+export const formatPresetName = (s: string) =>
   s.slice(0, 1).toUpperCase() + s.slice(1).toLowerCase();
 
 interface IPresetListItemProps {

--- a/src/renderer/components/PresetListItem.tsx
+++ b/src/renderer/components/PresetListItem.tsx
@@ -1,0 +1,74 @@
+import { useRef, useState } from 'react';
+import { useMouseDownOutside } from 'renderer/utils/utils';
+import IconButton, { IconName } from 'renderer/widgets/IconButton';
+import TextInput from 'renderer/widgets/TextInput';
+
+interface IPresetListItemProps {
+  value: string;
+  handleChange: (newValue: string) => void;
+  handleDelete: () => void;
+  isDisabled: boolean;
+  validate: (newValue: string) => string | undefined;
+}
+
+const PresetListItem = ({
+  value,
+  handleChange,
+  handleDelete,
+  isDisabled,
+  validate,
+}: IPresetListItemProps) => {
+  const editValueRef = useRef<HTMLInputElement>(null);
+  const [isEditMode, setIsEditMode] = useState<boolean>(false);
+
+  const handleEditClicked = () => {
+    setIsEditMode(true);
+  };
+
+  const handleEscape = () => {
+    setIsEditMode(false);
+  };
+
+  const handleInputChange = (newValue: string) => {
+    handleChange(newValue);
+    setIsEditMode(false);
+  };
+
+  // Close edit mode if the user clicks outside of the input
+  useMouseDownOutside<HTMLInputElement>(editValueRef, handleEscape);
+
+  return (
+    <>
+      {isEditMode ? (
+        <TextInput
+          ref={editValueRef}
+          value={value}
+          ariaLabel="Edit Preset Name"
+          isDisabled={false}
+          handleChange={handleInputChange}
+          handleEscape={handleEscape}
+          validate={validate}
+          updateOnSubmitOnly
+        />
+      ) : (
+        <>
+          {value}
+          <div className="row icons">
+            <IconButton
+              icon={IconName.EDIT}
+              handleClick={handleEditClicked}
+              isDisabled={isDisabled}
+            />
+            <IconButton
+              icon={IconName.DELETE}
+              handleClick={handleDelete}
+              isDisabled={isDisabled}
+            />
+          </div>
+        </>
+      )}
+    </>
+  );
+};
+
+export default PresetListItem;

--- a/src/renderer/components/PresetListItem.tsx
+++ b/src/renderer/components/PresetListItem.tsx
@@ -1,12 +1,7 @@
 import { useRef, useState } from 'react';
-import { useMouseDownOutside } from 'renderer/utils/utils';
+import { formatPresetName, useMouseDownOutside } from 'renderer/utils/utils';
 import IconButton, { IconName } from 'renderer/widgets/IconButton';
 import TextInput from 'renderer/widgets/TextInput';
-
-export const formatPresetName = (s: string) => {
-  const filteredS = s.replace(/[^a-zA-Z0-9|_|\-| ]+/, '');
-  return filteredS.slice(0, 1).toUpperCase() + filteredS.slice(1).toLowerCase();
-};
 
 interface IPresetListItemProps {
   value: string;

--- a/src/renderer/components/PresetListItem.tsx
+++ b/src/renderer/components/PresetListItem.tsx
@@ -10,21 +10,22 @@ export const formatPresetName = (s: string) => {
 
 interface IPresetListItemProps {
   value: string;
-  handleChange: (newValue: string) => void;
+  handleRename: (newValue: string) => void;
   handleDelete: () => void;
   isDisabled: boolean;
-  validate: (newValue: string) => string | undefined;
+  validate: (newValue: string) => string;
 }
 
 const PresetListItem = ({
   value,
-  handleChange,
+  handleRename,
   handleDelete,
   isDisabled,
   validate,
 }: IPresetListItemProps) => {
   const editValueRef = useRef<HTMLInputElement>(null);
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string>('');
 
   const handleEditClicked = () => {
     setIsEditMode(true);
@@ -32,11 +33,18 @@ const PresetListItem = ({
 
   const handleEscape = () => {
     setIsEditMode(false);
+    setErrorMessage('');
   };
 
   const handleInputChange = (newValue: string) => {
-    handleChange(newValue);
-    setIsEditMode(false);
+    const msg = validate(newValue);
+    setErrorMessage(msg);
+
+    if (!msg) {
+      // Rename preset if validation passes
+      handleRename(newValue);
+      setIsEditMode(false);
+    }
   };
 
   // Close edit mode if the user clicks outside of the input
@@ -50,10 +58,10 @@ const PresetListItem = ({
           value={value}
           ariaLabel="Edit Preset Name"
           isDisabled={false}
+          errorMessage={errorMessage}
           handleChange={handleInputChange}
           handleEscape={handleEscape}
           formatInput={formatPresetName}
-          validate={validate}
           updateOnSubmitOnly
         />
       ) : (

--- a/src/renderer/components/PresetListItem.tsx
+++ b/src/renderer/components/PresetListItem.tsx
@@ -3,8 +3,10 @@ import { useMouseDownOutside } from 'renderer/utils/utils';
 import IconButton, { IconName } from 'renderer/widgets/IconButton';
 import TextInput from 'renderer/widgets/TextInput';
 
-export const formatPresetName = (s: string) =>
-  s.slice(0, 1).toUpperCase() + s.slice(1).toLowerCase();
+export const formatPresetName = (s: string) => {
+  const filteredS = s.replace(/[^a-zA-Z0-9|_|\-| ]+/, '');
+  return filteredS.slice(0, 1).toUpperCase() + filteredS.slice(1).toLowerCase();
+};
 
 interface IPresetListItemProps {
   value: string;

--- a/src/renderer/components/PresetListItem.tsx
+++ b/src/renderer/components/PresetListItem.tsx
@@ -3,6 +3,9 @@ import { useMouseDownOutside } from 'renderer/utils/utils';
 import IconButton, { IconName } from 'renderer/widgets/IconButton';
 import TextInput from 'renderer/widgets/TextInput';
 
+const formatPresetName = (s: string) =>
+  s.slice(0, 1).toUpperCase() + s.slice(1).toLowerCase();
+
 interface IPresetListItemProps {
   value: string;
   handleChange: (newValue: string) => void;
@@ -47,6 +50,7 @@ const PresetListItem = ({
           isDisabled={false}
           handleChange={handleInputChange}
           handleEscape={handleEscape}
+          formatInput={formatPresetName}
           validate={validate}
           updateOnSubmitOnly
         />

--- a/src/renderer/styles/PresetsBar.scss
+++ b/src/renderer/styles/PresetsBar.scss
@@ -10,7 +10,7 @@
   grid-template-rows: repeat(3, min-content) 1fr min-content;
   padding: $spacing-m;
   gap: $spacing-s;
-  justify-items: center;
+  justify-items: stretch;
 
   // Styling of the background wrapper
   border-radius: $spacing-m;
@@ -18,20 +18,16 @@
 
   h4 {
     margin: 1em 0 1em 0;
+    justify-self: center;
   }
 
   .button {
     // Ensure button width matches the list width
-    width: calc(100% - $spacing-s - $spacing-xs);
+    margin: $spacing-xs 0;
   }
 
-  // Adjust spacing for preset name input field
   .preset-name {
-    width: 100%;
-
-    input[type='text'] {
-      width: 100%;
-    }
+    padding-top: $spacing-xs;
   }
 
   .preset-list-item {
@@ -39,10 +35,6 @@
     padding: $spacing-xs $spacing-s;
     justify-content: space-between;
     align-items: center;
-
-    input[type='text'] {
-      width: 100%;
-    }
 
     .icons {
       display: none;

--- a/src/renderer/styles/PresetsBar.scss
+++ b/src/renderer/styles/PresetsBar.scss
@@ -43,6 +43,14 @@
       .iconButton {
         outline: none;
 
+        &:hover svg path {
+          fill: $primary-lighter;
+        }
+
+        &:active svg path {
+          fill: $primary-light;
+        }
+
         &:focus-visible:not([aria-disabled='true']) {
           path {
             fill: $primary-lighter;

--- a/src/renderer/styles/TextInput.scss
+++ b/src/renderer/styles/TextInput.scss
@@ -10,8 +10,6 @@
     border-radius: 4px;
     padding: $spacing-xs;
     font-size: small;
-    // width: 52px;
-    // height: 18px;
     justify-content: space-between;
     align-content: center;
     align-items: center;
@@ -24,5 +22,11 @@
       border: solid $spacing-xxs $red;
       outline: $spacing-xxs solid $red;
     }
+  }
+
+  .errorText {
+    font-size: smaller;
+    color: $white;
+    padding-top: $spacing-s;
   }
 }

--- a/src/renderer/styles/TextInput.scss
+++ b/src/renderer/styles/TextInput.scss
@@ -1,19 +1,28 @@
 @import 'color';
 @import 'spacing';
 .text-input {
-  background: $primary-dark;
-  color: $white;
-  border: solid $spacing-xxs $secondary-default;
-  border-radius: 4px;
-  padding: $spacing-xs;
-  font-size: small;
-  // width: 52px;
-  // height: 18px;
-  justify-content: space-between;
-  align-content: center;
-  align-items: center;
+  flex: 1;
 
-  &:focus-visible {
-    outline: $spacing-xxs solid $white;
+  input[type='text'] {
+    background: $primary-dark;
+    color: $white;
+    border: solid $spacing-xxs $secondary-default;
+    border-radius: 4px;
+    padding: $spacing-xs;
+    font-size: small;
+    // width: 52px;
+    // height: 18px;
+    justify-content: space-between;
+    align-content: center;
+    align-items: center;
+
+    &:focus-visible {
+      outline: $spacing-xxs solid $white;
+    }
+
+    &[aria-invalid='true'] {
+      border: solid $spacing-xxs $red;
+      outline: $spacing-xxs solid $red;
+    }
   }
 }

--- a/src/renderer/styles/_color.scss
+++ b/src/renderer/styles/_color.scss
@@ -27,3 +27,6 @@ $analogous-2: #4ff7d8;
 // Shade
 $black: #000000;
 $white: #ffffff;
+
+// Additional
+$red: #f74f6e;

--- a/src/renderer/utils/equalizerApi.ts
+++ b/src/renderer/utils/equalizerApi.ts
@@ -127,6 +127,19 @@ export const deletePreset = (presetName: string): Promise<void> => {
   return promisifyResult(setterResponseHandler, channel);
 };
 
+/*
+ * Rename preset from an old name to a new one
+ * @returns { Promise<void> } if rename was succesfull
+ */
+export const renamePreset = (
+  oldName: string,
+  newName: string
+): Promise<void> => {
+  const channel = ChannelEnum.RENAME_PRESET;
+  window.electron.ipcRenderer.sendMessage(channel, [oldName, newName]);
+  return promisifyResult(setterResponseHandler, channel);
+};
+
 /**
  * Get a list of preset file names in preset folder
  * @returns { Promise<string[]> } if save was succesfull

--- a/src/renderer/utils/utils.ts
+++ b/src/renderer/utils/utils.ts
@@ -75,6 +75,28 @@ export const useClickOutside = <T extends HTMLElement = HTMLElement>(
   }, [handleClick]);
 };
 
+export const useMouseDownOutside = <T extends HTMLElement = HTMLElement>(
+  ref: RefObject<T>,
+  callback: () => void
+) => {
+  const handleMouseDown = useMemo(() => {
+    return (e: globalThis.MouseEvent) => {
+      if (!ref.current || ref.current.contains(e.target as Node)) {
+        return;
+      }
+
+      callback();
+    };
+  }, [callback, ref]);
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleMouseDown, true);
+
+    return () =>
+      document.removeEventListener('mousedown', handleMouseDown, true);
+  }, [handleMouseDown]);
+};
+
 export const useFocusOutside = <T extends HTMLElement = HTMLElement>(
   ref: RefObject<T>,
   callback: () => void

--- a/src/renderer/utils/utils.ts
+++ b/src/renderer/utils/utils.ts
@@ -16,6 +16,13 @@ export const sortHelper = (a: IFilter, b: IFilter) => a.frequency - b.frequency;
 export const range = (start: number, stop: number, step: number) =>
   Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step);
 
+export const formatPresetName = (s: string) => {
+  const filteredS = s.replace(/[^a-zA-Z0-9|_|\-| ]+/, '');
+  return filteredS.slice(0, 1).toUpperCase() + filteredS.slice(1).toLowerCase();
+};
+
+// *** CUSTOM HOOKS ***
+
 // https://overreacted.io/making-setinterval-declarative-with-react-hooks/
 export const useInterval = (callback: () => void, delay?: number) => {
   const savedCallback = useRef<() => void>();

--- a/src/renderer/widgets/List.tsx
+++ b/src/renderer/widgets/List.tsx
@@ -54,8 +54,8 @@ const List = ({
     }
   }, [focusOnRender, inputRefs, options, value]);
 
-  const onChange = useCallback(
-    (newValue: string) => {
+  const onClick = useCallback(
+    (newValue: string) => () => {
       handleChange(newValue);
     },
     [handleChange]
@@ -77,7 +77,7 @@ const List = ({
         return;
       }
       if (e.code === 'Enter') {
-        onChange(entry.value);
+        handleChange(entry.value);
       } else if (e.code === 'ArrowDown') {
         const next = Math.min(index + 1, options.length - 1);
         inputRefs[next].current?.focus();
@@ -86,7 +86,7 @@ const List = ({
         inputRefs[prev].current?.focus();
       }
     },
-    [inputRefs, isDisabled, onChange, options.length]
+    [inputRefs, isDisabled, handleChange, options.length]
   );
 
   return (
@@ -102,7 +102,7 @@ const List = ({
             key={entry.value}
             value={entry.value}
             aria-label={entry.label}
-            onClick={() => onChange(entry.value)}
+            onClick={onClick(entry.value)}
             onKeyDown={handleItemKeyPress(entry, index)}
             onMouseEnter={onMouseEnter(index)}
             tabIndex={0}

--- a/src/renderer/widgets/TextInput.tsx
+++ b/src/renderer/widgets/TextInput.tsx
@@ -5,7 +5,6 @@ import {
   KeyboardEvent,
   useCallback,
   useEffect,
-  useRef,
   useState,
 } from 'react';
 import '../styles/TextInput.scss';
@@ -36,17 +35,15 @@ const TextInput = forwardRef(
     ref: ForwardedRef<HTMLInputElement>
   ) => {
     const [storedValue, setStoredValue] = useState<string>(value);
-    const prevValue = useRef<string>(value);
 
     useEffect(() => {
       setStoredValue(value);
-      prevValue.current = value;
     }, [value]);
 
     const updateValue = useCallback(
       (newValue: string) => {
         // No need to validate if the value hasn't changed
-        if (prevValue.current === newValue) {
+        if (value === newValue) {
           // Treat this as an option for cancelling out of the input
           if (handleEscape) {
             handleEscape();
@@ -56,7 +53,7 @@ const TextInput = forwardRef(
           handleChange(newValue);
         }
       },
-      [handleChange, handleEscape]
+      [handleChange, handleEscape, value]
     );
 
     // Helper for detecting use of the ENTER key

--- a/src/renderer/widgets/TextInput.tsx
+++ b/src/renderer/widgets/TextInput.tsx
@@ -43,6 +43,7 @@ const TextInput = forwardRef(
 
     useEffect(() => {
       setStoredValue(value);
+      setErrorMessage(undefined);
     }, [value]);
 
     const validateAndSave = useCallback(
@@ -50,6 +51,7 @@ const TextInput = forwardRef(
         // No need to validate if the value hasn't changed
         if (prevValue.current === newValue) {
           handleChange(newValue);
+          setErrorMessage(undefined);
           return;
         }
 
@@ -112,7 +114,7 @@ const TextInput = forwardRef(
           tabIndex={isDisabled ? -1 : 0}
           aria-disabled={isDisabled}
         />
-        <div className="errorText">{errorMessage}</div>
+        {errorMessage && <div className="errorText">{errorMessage}</div>}
       </div>
     );
   }

--- a/src/renderer/widgets/TextInput.tsx
+++ b/src/renderer/widgets/TextInput.tsx
@@ -17,6 +17,7 @@ interface ITextInputProps {
   handleChange: (newValue: string) => void;
   handleEscape?: () => void;
   updateOnSubmitOnly?: boolean;
+  formatInput?: (value: string) => string;
   validate?: (newValue: string) => string | undefined;
 }
 
@@ -30,6 +31,7 @@ const TextInput = forwardRef(
       handleEscape,
       updateOnSubmitOnly,
       validate,
+      formatInput = (s) => s,
     }: ITextInputProps,
     ref: ForwardedRef<HTMLInputElement>
   ) => {
@@ -83,12 +85,12 @@ const TextInput = forwardRef(
     const onChange = useCallback(
       (e: ChangeEvent<HTMLInputElement>) => {
         const { value: input } = e.target;
-        setStoredValue(input);
+        setStoredValue(formatInput(input));
         if (!updateOnSubmitOnly) {
           validateAndSave();
         }
       },
-      [updateOnSubmitOnly, validateAndSave]
+      [formatInput, updateOnSubmitOnly, validateAndSave]
     );
 
     return (

--- a/src/renderer/widgets/TextInput.tsx
+++ b/src/renderer/widgets/TextInput.tsx
@@ -50,8 +50,12 @@ const TextInput = forwardRef(
       (newValue: string) => {
         // No need to validate if the value hasn't changed
         if (prevValue.current === newValue) {
-          handleChange(newValue);
           setErrorMessage(undefined);
+
+          // Treat this as an option for cancelling out of the input
+          if (handleEscape) {
+            handleEscape();
+          }
           return;
         }
 
@@ -71,7 +75,7 @@ const TextInput = forwardRef(
           prevValue.current = newValue;
         }
       },
-      [handleChange, validate]
+      [handleChange, handleEscape, validate]
     );
 
     // Helper for detecting use of the ENTER key

--- a/src/renderer/widgets/TextInput.tsx
+++ b/src/renderer/widgets/TextInput.tsx
@@ -45,29 +45,32 @@ const TextInput = forwardRef(
       setStoredValue(value);
     }, [value]);
 
-    const validateAndSave = useCallback(() => {
-      // No need to validate if the value hasn't changed
-      if (prevValue.current === storedValue) {
-        handleChange(storedValue);
-        return;
-      }
-
-      if (validate) {
-        // Perform validation
-        const msg = validate(storedValue);
-        setErrorMessage(msg);
-
-        // Save changes if validation has no errors
-        if (!msg) {
-          handleChange(storedValue);
-          prevValue.current = storedValue;
+    const validateAndSave = useCallback(
+      (newValue: string) => {
+        // No need to validate if the value hasn't changed
+        if (prevValue.current === newValue) {
+          handleChange(newValue);
+          return;
         }
-      } else {
-        // Save changes directly
-        handleChange(storedValue);
-        prevValue.current = storedValue;
-      }
-    }, [handleChange, storedValue, validate]);
+
+        if (validate) {
+          // Perform validation
+          const msg = validate(newValue);
+          setErrorMessage(msg);
+
+          // Save changes if validation has no errors
+          if (!msg) {
+            handleChange(newValue);
+            prevValue.current = newValue;
+          }
+        } else {
+          // Save changes directly
+          handleChange(newValue);
+          prevValue.current = newValue;
+        }
+      },
+      [handleChange, validate]
+    );
 
     // Helper for detecting use of the ENTER key
     const onKeyDown = useCallback(
@@ -76,18 +79,19 @@ const TextInput = forwardRef(
           handleEscape();
         }
         if (updateOnSubmitOnly && e.code === 'Enter') {
-          validateAndSave();
+          validateAndSave(storedValue);
         }
       },
-      [handleEscape, updateOnSubmitOnly, validateAndSave]
+      [handleEscape, storedValue, updateOnSubmitOnly, validateAndSave]
     );
 
     const onChange = useCallback(
       (e: ChangeEvent<HTMLInputElement>) => {
         const { value: input } = e.target;
-        setStoredValue(formatInput(input));
+        const formattedValue = formatInput(input);
+        setStoredValue(formattedValue);
         if (!updateOnSubmitOnly) {
-          validateAndSave();
+          validateAndSave(formattedValue);
         }
       },
       [formatInput, updateOnSubmitOnly, validateAndSave]
@@ -99,6 +103,7 @@ const TextInput = forwardRef(
           ref={ref}
           type="text"
           value={storedValue}
+          name={ariaLabel}
           aria-label={ariaLabel}
           aria-invalid={!!errorMessage}
           aria-errormessage={errorMessage}

--- a/src/renderer/widgets/TextInput.tsx
+++ b/src/renderer/widgets/TextInput.tsx
@@ -105,7 +105,7 @@ const TextInput = forwardRef(
           tabIndex={isDisabled ? -1 : 0}
           aria-disabled={isDisabled}
         />
-        <div>{errorMessage}</div>
+        <div className="errorText">{errorMessage}</div>
       </div>
     );
   }

--- a/src/renderer/widgets/TextInput.tsx
+++ b/src/renderer/widgets/TextInput.tsx
@@ -15,6 +15,7 @@ interface ITextInputProps {
   handleChange: (newValue: string) => void;
   handleEscape?: () => void;
   updateOnSubmitOnly?: boolean;
+  errorMessage?: string;
 }
 
 const TextInput = forwardRef(
@@ -26,6 +27,7 @@ const TextInput = forwardRef(
       handleChange,
       handleEscape,
       updateOnSubmitOnly,
+      errorMessage,
     }: ITextInputProps,
     ref: ForwardedRef<HTMLInputElement>
   ) => {
@@ -37,7 +39,7 @@ const TextInput = forwardRef(
 
     // Helper for detecting use of the ENTER key
     const onKeyDown = (e: KeyboardEvent) => {
-      if (handleEscape && e.code === 'Escape') {
+      if (handleEscape && (e.code === 'Escape' || e.code === 'Tab')) {
         handleEscape();
       }
       if (updateOnSubmitOnly && e.code === 'Enter') {
@@ -54,17 +56,21 @@ const TextInput = forwardRef(
     };
 
     return (
-      <input
-        ref={ref}
-        className="text-input"
-        type="text"
-        value={storedValue}
-        aria-label={ariaLabel}
-        onChange={onChange}
-        onKeyDown={onKeyDown}
-        tabIndex={isDisabled ? -1 : 0}
-        aria-disabled={isDisabled}
-      />
+      <div className="col text-input">
+        <input
+          ref={ref}
+          type="text"
+          value={storedValue}
+          aria-label={ariaLabel}
+          aria-invalid={!!errorMessage}
+          aria-errormessage={errorMessage}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+          tabIndex={isDisabled ? -1 : 0}
+          aria-disabled={isDisabled}
+        />
+        <div>{errorMessage}</div>
+      </div>
     );
   }
 );


### PR DESCRIPTION
# Summary
Allow users to rename existing presets. 

Note: Pointing this PR at jat-30 for now. Will perform the necessary rebase / clean up necessary once [jat-30](https://github.com/h39s/AQUA/pull/31) is merged.

## Changes
- Add function for renaming preset files
- Improve interaction with the text input for renaming
   - Reduce scope of events that causes it to be hidden
- Add validation of preset names
  - Format names to always be lower case with first letter being capitalized
  - Add red coloring for error case and text describing the error

## Refactor
- Move `PresetListItem` into its own file
- Add more `useMemo`s and `useCallback`s to reduce recomputation of functions
- Style improvements

## Tests
- Added a test file for `TextInput`
- Added a test file for `PresetListItem`

## Screenshot
<img width="270" alt="image" src="https://user-images.githubusercontent.com/30204513/214476437-69eb7627-1ace-405e-817e-2c79d4359d64.png">
<img width="273" alt="image" src="https://user-images.githubusercontent.com/30204513/214476521-c4e26877-18af-41de-9204-81a92a40f2da.png">
