### PR TITLE
JAT 95 Move loading state to individual sections

### DIFF
--- a/src/__tests__/cucumber_tests/shared_steps/aqua.ts
+++ b/src/__tests__/cucumber_tests/shared_steps/aqua.ts
@@ -43,7 +43,7 @@ export const givenEnabledState = (
     async (state: string) => {
       const desiredState = state === 'enabled';
       const equalizerSwitch = await webdriver.driver.$(
-        '.sideBar label[class="switch"][for="equalizerEnabler"]'
+        '.side-bar label[class="switch"][for="equalizerEnabler"]'
       );
 
       const switchOn = await equalizerSwitch
@@ -63,7 +63,7 @@ export const whenSetEnabledState = (
   webdriver: { driver: Driver | undefined }
 ) => {
   when(/^I toggle the equalizer state$/, async () => {
-    const equalizerSwitch = await webdriver.driver.$('.sideBar .switch');
+    const equalizerSwitch = await webdriver.driver.$('.side-bar .switch');
     equalizerSwitch.click();
     // wait 1000 ms for the action.
     await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -77,7 +77,7 @@ export const givenAutoPreAmpState = (
   given(/^auto pre-amp is (on|off)$/, async (state: string) => {
     const desiredState = state === 'on';
     const equalizerSwitch = await webdriver.driver.$(
-      '.sideBar label[class="switch"][for="autoPreAmpEnabler"]'
+      '.side-bar label[class="switch"][for="autoPreAmpEnabler"]'
     );
 
     const switchOn = await equalizerSwitch

--- a/src/__tests__/cucumber_tests/shared_steps/aquaGraph.ts
+++ b/src/__tests__/cucumber_tests/shared_steps/aquaGraph.ts
@@ -8,7 +8,7 @@ export const givenChartViewEnabledState = (
   when(/^ChartView is (enabled|disabled)$/, async (state: string) => {
     const desiredState = state === 'enabled';
     const graphViewSwitch = await webdriver.driver.$(
-      '.sideBar label[class="switch"][for="graphViewEnabler"]'
+      '.side-bar label[class="switch"][for="graphViewEnabler"]'
     );
 
     const switchOn = await graphViewSwitch

--- a/src/__tests__/cucumber_tests/shared_steps/aquaSlider.ts
+++ b/src/__tests__/cucumber_tests/shared_steps/aquaSlider.ts
@@ -8,21 +8,21 @@ export const givenBandCount = (
 ) => {
   given(/^there are (\d+) frequency bands$/, async (count: number) => {
     let sliderElems = await webdriver.driver
-      .$('.mainContent')
+      .$('.main-content')
       .$$('.bandWrapper');
     let sliderLength = sliderElems.length;
 
     while (sliderLength > count) {
       // Find any delete button
       const removeButton = await webdriver.driver
-        .$('.mainContent')
+        .$('.main-content')
         .$('.removeFilter');
       removeButton.click();
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
       do {
         sliderElems = await webdriver.driver
-          .$('.mainContent')
+          .$('.main-content')
           .$$('.bandWrapper');
       } while (sliderElems.length === sliderLength);
       sliderLength = sliderElems.length;
@@ -31,14 +31,14 @@ export const givenBandCount = (
     while (sliderLength < count) {
       // Find any add button
       const addButton = await webdriver.driver
-        .$('.mainContent')
+        .$('.main-content')
         .$('.addFilter');
       addButton.click();
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
       do {
         sliderElems = await webdriver.driver
-          .$('.mainContent')
+          .$('.main-content')
           .$$('.bandWrapper');
       } while (sliderElems.length === sliderLength);
       sliderLength = sliderElems.length;
@@ -55,12 +55,12 @@ export const whenChangeBandCount = (
 
     if (isAdd) {
       const addButton = await webdriver.driver
-        .$('.mainContent')
+        .$('.main-content')
         .$('.addFilter');
       addButton.click();
     } else {
       const removeButton = await webdriver.driver
-        .$('.mainContent')
+        .$('.main-content')
         .$('.removeFilter');
       removeButton.click();
     }
@@ -78,7 +78,7 @@ const setFrequencyGain = async (
   position: string
 ) => {
   const element = await webdriver.driver.$(
-    `.mainContent input[name="${frequency}-gain-range"]`
+    `.main-content input[name="${frequency}-gain-range"]`
   );
   const coord = { x: 0, y: 0 };
   if (position === 'top') {
@@ -111,7 +111,7 @@ export const whenSetFrequencyGainWithText = (
     /^I set gain of slider of frequency (\d+)Hz to (\d+(?:.\d+)?)db$/,
     async (frequency: number, gain: string) => {
       const inputElement = await webdriver.driver.$(
-        `.mainContent label[for="${frequency}-gain-number"] input`
+        `.main-content label[for="${frequency}-gain-number"] input`
       );
       await inputElement.setValue(parseFloat(gain));
       await inputElement.keys('Tab');
@@ -129,7 +129,7 @@ const setFrequencyQuality = async (
   quality: string
 ) => {
   const inputElement = await webdriver.driver.$(
-    `.mainContent label[for="${frequency}-quality"] input`
+    `.main-content label[for="${frequency}-quality"] input`
   );
   await inputElement.setValue(parseFloat(quality));
   await inputElement.keys('Tab');
@@ -169,7 +169,7 @@ export const whenSetFrequencyQualityUsingArrows = (
     /^I click on the (up|down) arrow for the quality for frequency (\d+)Hz (\d+) times$/,
     async (direction: string, frequency: number, times: number) => {
       const label = await webdriver.driver.$(
-        `.mainContent label[for="${frequency}-quality"]`
+        `.main-content label[for="${frequency}-quality"]`
       );
       const hiddenButton = await label.$(`.arrow-${direction}`);
       expect(await hiddenButton.isDisplayed()).toBeFalsy();
@@ -198,7 +198,7 @@ const setFrequencyFilterType = async (
   }
   const filterTypeAsEnum = filterType as FilterTypeEnum;
   const dropdownElem = await webdriver.driver
-    .$('.mainContent')
+    .$('.main-content')
     .$(`.dropdown [aria-label="${frequency}-filter-type"]`);
 
   expect(dropdownElem).not.toBeNull();
@@ -315,7 +315,7 @@ const setPreAmpGain = async (
   position: string
 ) => {
   const element = await webdriver.driver.$(
-    '.sideBar input[name="Pre-Amplification Gain (dB)-range"]'
+    '.side-bar input[name="Pre-Amplification Gain (dB)-range"]'
   );
   const coord = { x: 0, y: 0 };
   if (position === 'top') {
@@ -333,7 +333,7 @@ const setPreAmpGainNumber = async (
   gain: number
 ) => {
   const inputElement = await webdriver.driver.$(
-    '.sideBar input[name="Pre-Amplification Gain (dB)-number"]'
+    '.side-bar input[name="Pre-Amplification Gain (dB)-number"]'
   );
   await inputElement.setValue(gain);
   await inputElement.keys('Tab');
@@ -370,7 +370,7 @@ export const whenSetPreAmpGainUsingArrows = (
     /^I click on the (up|down) arrow for the preamp gain (\d+) times$/,
     async (direction: string, times: number) => {
       const button = await webdriver.driver
-        .$('.sideBar')
+        .$('.side-bar')
         .$(`.arrow-${direction}`);
 
       for (let i = 0; i < times; i += 1) {

--- a/src/__tests__/cucumber_tests/shared_steps/config.ts
+++ b/src/__tests__/cucumber_tests/shared_steps/config.ts
@@ -144,7 +144,9 @@ export const thenFrequencyGain = (
   then(
     /^Aqua config file should show gain of (-?\d+)dB for frequency (\d+)Hz$/,
     async (gain: string, frequency: string) => {
-      const sliderElems = await webdriver.driver.$('.mainContent').$$('.range');
+      const sliderElems = await webdriver.driver
+        .$('.main-content')
+        .$$('.range');
       for (let i = 0; i < sliderElems.length; i += 1) {
         const element = await sliderElems[i].$('input');
         const name = await element.getAttribute('name');
@@ -167,7 +169,9 @@ export const thenFrequencyQuality = (
   then(
     /^Aqua config file should show a quality of (\d+.?\d+) for the band with frequency (\d+)Hz$/,
     async (quality: string, frequency: string) => {
-      const sliderElems = await webdriver.driver.$('.mainContent').$$('.range');
+      const sliderElems = await webdriver.driver
+        .$('.main-content')
+        .$$('.range');
       for (let i = 0; i < sliderElems.length; i += 1) {
         const element = await sliderElems[i].$('input');
         const name = await element.getAttribute('name');
@@ -190,7 +194,9 @@ export const thenFrequencyFilterType = (
   then(
     /^Aqua config file should show the (\w+) filter type for the band with frequency (\d+)Hz$/,
     async (filterType: string, frequency: string) => {
-      const sliderElems = await webdriver.driver.$('.mainContent').$$('.range');
+      const sliderElems = await webdriver.driver
+        .$('.main-content')
+        .$$('.range');
       for (let i = 0; i < sliderElems.length; i += 1) {
         const element = await sliderElems[i].$('input');
         const name = await element.getAttribute('name');

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -99,7 +99,7 @@ export const getDefaultState = (): IState => {
   return {
     isEnabled: true,
     isAutoPreAmpOn: true,
-    isGraphViewOn: false,
+    isGraphViewOn: true,
     preAmp: 0,
     filters: getDefaultFilters(),
   };

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -42,7 +42,7 @@ export const FilterTypeToLabelMap: Record<FilterTypeEnum, string> = {
 };
 
 export const WINDOW_WIDTH = 1428;
-export const WINDOW_HEIGHT = 626;
+export const WINDOW_HEIGHT = 625;
 export const WINDOW_HEIGHT_EXPANDED = 1036;
 
 export const PRESETS_DIR = 'presets/';

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,18 +12,10 @@ const AppContent = () => {
 
   return (
     <>
-      {isLoading ? (
-        <div className="center full row">
-          <h1>Loading...</h1>
-        </div>
-      ) : (
-        <>
-          <SideBar />
-          <MainContent />
-          <PresetsBar />
-          <FrequencyResponseChart />
-        </>
-      )}
+      <SideBar />
+      <MainContent />
+      <PresetsBar />
+      <FrequencyResponseChart />
       {globalError && (
         <PrereqMissingModal
           isLoading={isLoading}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,20 +12,12 @@ const AppContent = () => {
 
   return (
     <>
-      {isLoading ? (
-        <div className="center full row">
-          <h1>Loading...</h1>
-        </div>
-      ) : (
-        <>
-          <div className="parameteric-wrapper row">
-            <SideBar />
-            <MainContent />
-            <PresetsBar />
-          </div>
-          <FrequencyResponseChart />
-        </>
-      )}
+      <div className="parameteric-wrapper row">
+        <SideBar />
+        <MainContent />
+        <PresetsBar />
+      </div>
+      <FrequencyResponseChart />
       {globalError && (
         <PrereqMissingModal
           isLoading={isLoading}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,12 +12,18 @@ const AppContent = () => {
 
   return (
     <>
-      <div className="parameteric-wrapper row">
-        <SideBar />
-        <MainContent />
-        <PresetsBar />
-      </div>
-      <FrequencyResponseChart />
+      {isLoading ? (
+        <div className="center full row">
+          <h1>Loading...</h1>
+        </div>
+      ) : (
+        <>
+          <SideBar />
+          <MainContent />
+          <PresetsBar />
+          <FrequencyResponseChart />
+        </>
+      )}
       {globalError && (
         <PrereqMissingModal
           isLoading={isLoading}

--- a/src/renderer/MainContent.tsx
+++ b/src/renderer/MainContent.tsx
@@ -7,9 +7,13 @@ import AddSliderDivider from './components/AddSliderDivider';
 import SortWrapper from './SortWrapper';
 
 const MainContent = () => {
-  const { filters } = useAquaContext();
+  const { filters, isLoading } = useAquaContext();
   const wrapperRef = createRef<HTMLDivElement>();
-  return (
+  return isLoading ? (
+    <div className="center full row">
+      <h1>Loading...</h1>
+    </div>
+  ) : (
     <div className="center mainContent">
       <div className="col center bandLabel">
         <span className="rowLabel">Filter Type</span>

--- a/src/renderer/MainContent.tsx
+++ b/src/renderer/MainContent.tsx
@@ -5,13 +5,14 @@ import { useAquaContext } from './utils/AquaContext';
 import './styles/MainContent.scss';
 import AddSliderDivider from './components/AddSliderDivider';
 import SortWrapper from './SortWrapper';
+import Spinner from './icons/Spinner';
 
 const MainContent = () => {
   const { filters, isLoading } = useAquaContext();
   const wrapperRef = createRef<HTMLDivElement>();
   return isLoading ? (
     <div className="center full row">
-      <h1>Loading...</h1>
+      <Spinner />
     </div>
   ) : (
     <div className="center main-content">

--- a/src/renderer/MainContent.tsx
+++ b/src/renderer/MainContent.tsx
@@ -14,17 +14,17 @@ const MainContent = () => {
       <h1>Loading...</h1>
     </div>
   ) : (
-    <div className="center mainContent">
-      <div className="col center bandLabel">
-        <span className="rowLabel">Filter Type</span>
-        <span className="rowLabel">Frequency (Hz)</span>
+    <div className="center main-content">
+      <div className="col center band-label">
+        <span className="row-label">Filter Type</span>
+        <span className="row-label">Frequency (Hz)</span>
         <div className="col">
           <span>+30dB</span>
           <span>0dB</span>
           <span>-30dB</span>
         </div>
-        <span className="rowLabel">Gain (dB)</span>
-        <span className="rowLabel">Quality</span>
+        <span className="row-label">Gain (dB)</span>
+        <span className="row-label">Quality</span>
       </div>
       <div ref={wrapperRef} className="bands row center">
         <AddSliderDivider

--- a/src/renderer/PresetsBar.tsx
+++ b/src/renderer/PresetsBar.tsx
@@ -198,9 +198,9 @@ const PresetsBar = () => {
   }, [globalError, presetNames]);
 
   return (
-    <div className="presetsBar">
+    <div className="presets-bar">
       <h4>Preset Menu</h4>
-      <div className="row center presetName">
+      <div className="row center preset-name">
         Name:&nbsp;
         <TextInput
           value={presetName}
@@ -221,7 +221,7 @@ const PresetsBar = () => {
         name="preset"
         options={options}
         className="full"
-        itemClassName="presetListItem"
+        itemClassName="preset-list-item"
         value={presetName}
         handleChange={handleChangeSelectedPreset}
         isDisabled={!!globalError}

--- a/src/renderer/SideBar.tsx
+++ b/src/renderer/SideBar.tsx
@@ -6,12 +6,13 @@ import './styles/SideBar.scss';
 import { useAquaContext } from './utils/AquaContext';
 import AutoPreAmpEnablerSwitch from './components/AutoPreAmpEnablerSwitch';
 import GraphViewSwitch from './components/GraphViewSwitch';
+import Spinner from './icons/Spinner';
 
 const SideBar = () => {
   const MIN = -30;
   const MAX = 30;
 
-  const { preAmp, setGlobalError, setPreAmp, setAutoPreAmpOn } =
+  const { isLoading, preAmp, setGlobalError, setPreAmp, setAutoPreAmpOn } =
     useAquaContext();
 
   const setGain = async (newValue: number) => {
@@ -27,31 +28,39 @@ const SideBar = () => {
 
   return (
     <div className="col sideBar center">
-      <div className="col center">
-        <h4>Enable</h4>
-        <EqualizerEnablerSwitch id="equalizerEnabler" />
-      </div>
-      <div>
-        <h4>Pre-Amp Gain</h4>
-        <div>+30 dB</div>
-        <Slider
-          name="Pre-Amplification Gain (dB)"
-          min={MIN}
-          max={MAX}
-          value={preAmp}
-          sliderHeight={110}
-          setValue={setGain}
-          label="-30 dB"
-        />
-      </div>
-      <div className="col center">
-        <h4>Auto Pre-amp</h4>
-        <AutoPreAmpEnablerSwitch id="autoPreAmpEnabler" />
-      </div>
-      <div className="col center">
-        <h4>Graph EQ</h4>
-        <GraphViewSwitch id="graphViewEnabler" />
-      </div>
+      {isLoading ? (
+        <div className="center full row">
+          <Spinner />
+        </div>
+      ) : (
+        <>
+          <div className="col center">
+            <h4>Enable</h4>
+            <EqualizerEnablerSwitch id="equalizerEnabler" />
+          </div>
+          <div>
+            <h4>Pre-Amp Gain</h4>
+            <div>+30 dB</div>
+            <Slider
+              name="Pre-Amplification Gain (dB)"
+              min={MIN}
+              max={MAX}
+              value={preAmp}
+              sliderHeight={110}
+              setValue={setGain}
+              label="-30 dB"
+            />
+          </div>
+          <div className="col center">
+            <h4>Auto Pre-amp</h4>
+            <AutoPreAmpEnablerSwitch id="autoPreAmpEnabler" />
+          </div>
+          <div className="col center">
+            <h4>Graph EQ</h4>
+            <GraphViewSwitch id="graphViewEnabler" />
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/renderer/SideBar.tsx
+++ b/src/renderer/SideBar.tsx
@@ -27,7 +27,7 @@ const SideBar = () => {
   };
 
   return (
-    <div className="col sideBar center">
+    <div className="col side-bar center">
       {isLoading ? (
         <div className="center full row">
           <Spinner />

--- a/src/renderer/graph/FrequencyResponseChart.tsx
+++ b/src/renderer/graph/FrequencyResponseChart.tsx
@@ -1,5 +1,6 @@
 import { IFilter } from 'common/constants';
 import { useEffect, useMemo, useRef } from 'react';
+import Spinner from 'renderer/icons/Spinner';
 import { useAquaContext } from 'renderer/utils/AquaContext';
 import { setMainPreAmp } from 'renderer/utils/equalizerApi';
 import { clamp } from 'renderer/utils/utils';
@@ -92,7 +93,7 @@ const FrequencyResponseChart = () => {
         <div className="graph-wrapper">
           {isLoading ? (
             <div className="center full row">
-              <h1>Loading...</h1>
+              <Spinner />
             </div>
           ) : (
             <Chart data={chartData} dimensions={dimensions} />

--- a/src/renderer/graph/FrequencyResponseChart.tsx
+++ b/src/renderer/graph/FrequencyResponseChart.tsx
@@ -17,8 +17,14 @@ const isFilterEqual = (f1: IFilter, f2: IFilter) => {
 };
 
 const FrequencyResponseChart = () => {
-  const { filters, preAmp, isAutoPreAmpOn, setPreAmp, isGraphViewOn } =
-    useAquaContext();
+  const {
+    filters,
+    isAutoPreAmpOn,
+    isGraphViewOn,
+    isLoading,
+    preAmp,
+    setPreAmp,
+  } = useAquaContext();
   const prevFilters = useRef<IFilter[]>([]);
   const prevFilterLines = useRef<ChartDataPoint[][]>([]);
 
@@ -84,7 +90,13 @@ const FrequencyResponseChart = () => {
     <>
       {isGraphViewOn && (
         <div className="graph-wrapper">
-          <Chart data={chartData} dimensions={dimensions} />
+          {isLoading ? (
+            <div className="center full row">
+              <h1>Loading...</h1>
+            </div>
+          ) : (
+            <Chart data={chartData} dimensions={dimensions} />
+          )}
         </div>
       )}
     </>

--- a/src/renderer/icons/Spinner.tsx
+++ b/src/renderer/icons/Spinner.tsx
@@ -1,0 +1,23 @@
+import '../styles/Spinner.scss';
+
+const Spinner = () => (
+  <div className="windows8">
+    <div className="wBall" id="wBall_1">
+      <div className="wInnerBall" />
+    </div>
+    <div className="wBall" id="wBall_2">
+      <div className="wInnerBall" />
+    </div>
+    <div className="wBall" id="wBall_3">
+      <div className="wInnerBall" />
+    </div>
+    <div className="wBall" id="wBall_4">
+      <div className="wInnerBall" />
+    </div>
+    <div className="wBall" id="wBall_5">
+      <div className="wInnerBall" />
+    </div>
+  </div>
+);
+
+export default Spinner;

--- a/src/renderer/index.ejs
+++ b/src/renderer/index.ejs
@@ -9,7 +9,7 @@
     <title>AQUA</title>
   </head>
   <body>
-    <header class="titlebar row">
+    <header class="title-bar row">
       <span>AQUA</span>
     </header>
     <div id="root"></div>

--- a/src/renderer/styles/App.scss
+++ b/src/renderer/styles/App.scss
@@ -19,7 +19,7 @@ body {
     // Spacing and height
     padding: $spacing-m;
     padding-top: $spacing-s;
-    height: calc(100vh - $titlebar-height - $spacing-m - $spacing-s);
+    height: calc(100vh - $title-bar-height - $spacing-m - $spacing-s);
     width: calc(100vw - 2 * $spacing-m);
 
     // Add flex so we can split space bweteen parametric and graph views
@@ -29,9 +29,9 @@ body {
   }
 }
 
-.titlebar {
+.title-bar {
   background-color: $primary-dark;
-  height: $titlebar-height;
+  height: $title-bar-height;
   width: 100%;
   -webkit-app-region: drag; /* Allow user to drag the window using this titlebar */
   -webkit-user-select: none; /* Prevent user from selecting things */

--- a/src/renderer/styles/App.scss
+++ b/src/renderer/styles/App.scss
@@ -22,9 +22,13 @@ body {
     height: calc(100vh - $title-bar-height - $spacing-m - $spacing-s);
     width: calc(100vw - 2 * $spacing-m);
 
-    // Add flex so we can split space bweteen parametric and graph views
-    display: flex;
-    flex-direction: column;
+    // Add grid for layout
+    display: grid;
+    grid-template-areas:
+      'side-bar main-content presets-bar'
+      'graph-wrapper graph-wrapper graph-wrapper';
+    grid-template-columns: max-content 1fr $preset-bar-width;
+    grid-template-rows: $equalizer-height 1fr;
     gap: $spacing-s;
   }
 }
@@ -46,14 +50,8 @@ body {
   }
 }
 
-.parameteric-wrapper {
-  flex: 0;
-  gap: $spacing-s;
-  height: $equalizer-height;
-}
-
 .graph-wrapper {
-  flex: 1;
+  grid-area: graph-wrapper;
   border-radius: $spacing-m;
   border: $spacing-xxs solid $secondary-default;
 }

--- a/src/renderer/styles/App.scss
+++ b/src/renderer/styles/App.scss
@@ -27,7 +27,7 @@ body {
     grid-template-areas:
       'side-bar main-content presets-bar'
       'graph-wrapper graph-wrapper graph-wrapper';
-    grid-template-columns: max-content 1fr $preset-bar-width;
+    grid-template-columns: minmax($sidebar-width, max-content) 1fr $preset-bar-width;
     grid-template-rows: $equalizer-height 1fr;
     gap: $spacing-s;
   }

--- a/src/renderer/styles/FrequencyBand.scss
+++ b/src/renderer/styles/FrequencyBand.scss
@@ -12,7 +12,7 @@
   .band {
     // width: $band-width;
     gap: $spacing-s;
-    .numberInput,
+    .number-input,
     .dropdown {
       align-self: center;
 

--- a/src/renderer/styles/MainContent.scss
+++ b/src/renderer/styles/MainContent.scss
@@ -5,11 +5,11 @@
 // band width and height from constants file
 
 .main-content {
-  width: $content-width;
+  grid-area: main-content;
   display: grid;
   grid-template-columns: 128px 1fr;
-  grid-template-rows: 100%;
   gap: $spacing-s;
+
   // Add additional space to the right to balance the spacing better
   padding: $spacing-s $spacing-l $spacing-s $spacing-s;
   justify-items: center;

--- a/src/renderer/styles/MainContent.scss
+++ b/src/renderer/styles/MainContent.scss
@@ -4,7 +4,7 @@
 
 // band width and height from constants file
 
-.mainContent {
+.main-content {
   width: $content-width;
   display: grid;
   grid-template-columns: 128px 1fr;
@@ -17,7 +17,7 @@
   border-radius: $spacing-m;
   border: $spacing-xxs solid $secondary-default;
 
-  .bandLabel {
+  .band-label {
     height: $band-height;
     justify-content: flex-start;
     gap: $spacing-s;
@@ -27,7 +27,7 @@
       height: 100%;
     }
 
-    .rowLabel {
+    .row-label {
       margin: $spacing-s 0;
     }
 

--- a/src/renderer/styles/NumberInput.scss
+++ b/src/renderer/styles/NumberInput.scss
@@ -3,10 +3,10 @@
 
 $input-height: 24px;
 
-.numberInput {
+.number-input {
   gap: $spacing-s;
 
-  .inputWrapper {
+  .input-wrapper {
     position: relative; // necessary so that the absolutely positioned asterisks will scroll with the input
     border: $spacing-xxs solid $secondary-default;
     border-radius: 4px;

--- a/src/renderer/styles/NumberInput.scss
+++ b/src/renderer/styles/NumberInput.scss
@@ -1,7 +1,6 @@
 @import 'color';
+@import 'constant';
 @import 'spacing';
-
-$input-height: 24px;
 
 .number-input {
   gap: $spacing-s;

--- a/src/renderer/styles/PresetsBar.scss
+++ b/src/renderer/styles/PresetsBar.scss
@@ -2,7 +2,7 @@
 @import 'color';
 @import 'spacing';
 
-.presetsBar {
+.presets-bar {
   // Spacing of the contents
   display: grid;
   grid-template-rows: repeat(3, min-content) auto min-content;
@@ -12,8 +12,8 @@
 
   // Sizing of the wraooer
   height: calc(100% - 2 * $spacing-m);
-  min-width: $presetbar-width;
-  max-width: $presetbar-width;
+  min-width: $preset-bar-width;
+  max-width: $preset-bar-width;
 
   // Styling of the background wrapper
   border-radius: $spacing-m;
@@ -29,7 +29,7 @@
   }
 
   // Adjust spacing for preset name input field
-  .presetName {
+  .preset-name {
     width: 100%;
 
     input[type='text'] {
@@ -37,7 +37,7 @@
     }
   }
 
-  .presetListItem {
+  .preset-list-item {
     min-height: $spacing-l;
     padding: $spacing-xs $spacing-s;
     justify-content: space-between;

--- a/src/renderer/styles/PresetsBar.scss
+++ b/src/renderer/styles/PresetsBar.scss
@@ -3,17 +3,14 @@
 @import 'spacing';
 
 .presets-bar {
+  grid-area: presets-bar;
+
   // Spacing of the contents
   display: grid;
-  grid-template-rows: repeat(3, min-content) auto min-content;
+  grid-template-rows: repeat(3, min-content) 1fr min-content;
   padding: $spacing-m;
   gap: $spacing-s;
   justify-items: center;
-
-  // Sizing of the wraooer
-  height: calc(100% - 2 * $spacing-m);
-  min-width: $preset-bar-width;
-  max-width: $preset-bar-width;
 
   // Styling of the background wrapper
   border-radius: $spacing-m;

--- a/src/renderer/styles/SideBar.scss
+++ b/src/renderer/styles/SideBar.scss
@@ -2,8 +2,9 @@
 @import 'color';
 @import 'spacing';
 
-.sideBar {
-  min-width: $sidebar-width;
+.side-bar {
+  grid-area: side-bar;
+  min-width: $side-bar-width;
   padding: $spacing-s;
 
   border-radius: $spacing-m;

--- a/src/renderer/styles/SideBar.scss
+++ b/src/renderer/styles/SideBar.scss
@@ -4,8 +4,7 @@
 
 .side-bar {
   grid-area: side-bar;
-  min-width: $side-bar-width;
-  padding: $spacing-s;
+  padding: $spacing-s $spacing-l;
 
   border-radius: $spacing-m;
   background: $primary-default;

--- a/src/renderer/styles/Spinner.scss
+++ b/src/renderer/styles/Spinner.scss
@@ -20,11 +20,11 @@ $spinner-dot-height: 6px;
   -ms-transform: rotate(225deg);
   -webkit-transform: rotate(225deg);
   -moz-transform: rotate(225deg);
-  animation: orbit 6.96s infinite;
-  -o-animation: orbit 6.96s infinite;
-  -ms-animation: orbit 6.96s infinite;
-  -webkit-animation: orbit 6.96s infinite;
-  -moz-animation: orbit 6.96s infinite;
+  animation: orbit 3.48s infinite;
+  -o-animation: orbit 3.48s infinite;
+  -ms-animation: orbit 3.48s infinite;
+  -webkit-animation: orbit 3.48s infinite;
+  -moz-animation: orbit 3.48s infinite;
 }
 
 .windows8 .wBall .wInnerBall {
@@ -38,43 +38,43 @@ $spinner-dot-height: 6px;
 }
 
 .windows8 #wBall_1 {
-  animation-delay: 1.52s;
-  -o-animation-delay: 1.52s;
-  -ms-animation-delay: 1.52s;
-  -webkit-animation-delay: 1.52s;
-  -moz-animation-delay: 1.52s;
+  animation-delay: 0.76s;
+  -o-animation-delay: 0.76s;
+  -ms-animation-delay: 0.76s;
+  -webkit-animation-delay: 0.76s;
+  -moz-animation-delay: 0.76s;
 }
 
 .windows8 #wBall_2 {
-  animation-delay: 0.3s;
-  -o-animation-delay: 0.3s;
-  -ms-animation-delay: 0.3s;
-  -webkit-animation-delay: 0.3s;
-  -moz-animation-delay: 0.3s;
+  animation-delay: 0.15s;
+  -o-animation-delay: 0.15s;
+  -ms-animation-delay: 0.15s;
+  -webkit-animation-delay: 0.15s;
+  -moz-animation-delay: 0.15s;
 }
 
 .windows8 #wBall_3 {
+  animation-delay: 0.305s;
+  -o-animation-delay: 0.305s;
+  -ms-animation-delay: 0.305s;
+  -webkit-animation-delay: 0.305s;
+  -moz-animation-delay: 0.305s;
+}
+
+.windows8 #wBall_4 {
+  animation-delay: 0.455s;
+  -o-animation-delay: 0.455s;
+  -ms-animation-delay: 0.455s;
+  -webkit-animation-delay: 0.455s;
+  -moz-animation-delay: 0.455s;
+}
+
+.windows8 #wBall_5 {
   animation-delay: 0.61s;
   -o-animation-delay: 0.61s;
   -ms-animation-delay: 0.61s;
   -webkit-animation-delay: 0.61s;
   -moz-animation-delay: 0.61s;
-}
-
-.windows8 #wBall_4 {
-  animation-delay: 0.91s;
-  -o-animation-delay: 0.91s;
-  -ms-animation-delay: 0.91s;
-  -webkit-animation-delay: 0.91s;
-  -moz-animation-delay: 0.91s;
-}
-
-.windows8 #wBall_5 {
-  animation-delay: 1.22s;
-  -o-animation-delay: 1.22s;
-  -ms-animation-delay: 1.22s;
-  -webkit-animation-delay: 1.22s;
-  -moz-animation-delay: 1.22s;
 }
 
 @keyframes orbit {

--- a/src/renderer/styles/Spinner.scss
+++ b/src/renderer/styles/Spinner.scss
@@ -1,0 +1,402 @@
+@import 'color';
+$spinner-height: 40px;
+$spinner-dot-height: 6px;
+
+// From https://cssload.net/
+.windows8 {
+  position: relative;
+  width: $spinner-height;
+  height: $spinner-height;
+  margin: auto;
+}
+
+.windows8 .wBall {
+  position: absolute;
+  width: $spinner-height;
+  height: $spinner-height;
+  opacity: 0;
+  transform: rotate(225deg);
+  -o-transform: rotate(225deg);
+  -ms-transform: rotate(225deg);
+  -webkit-transform: rotate(225deg);
+  -moz-transform: rotate(225deg);
+  animation: orbit 6.96s infinite;
+  -o-animation: orbit 6.96s infinite;
+  -ms-animation: orbit 6.96s infinite;
+  -webkit-animation: orbit 6.96s infinite;
+  -moz-animation: orbit 6.96s infinite;
+}
+
+.windows8 .wBall .wInnerBall {
+  position: absolute;
+  width: $spinner-dot-height;
+  height: $spinner-dot-height;
+  background: $white;
+  left: 0px;
+  top: 0px;
+  border-radius: 6px;
+}
+
+.windows8 #wBall_1 {
+  animation-delay: 1.52s;
+  -o-animation-delay: 1.52s;
+  -ms-animation-delay: 1.52s;
+  -webkit-animation-delay: 1.52s;
+  -moz-animation-delay: 1.52s;
+}
+
+.windows8 #wBall_2 {
+  animation-delay: 0.3s;
+  -o-animation-delay: 0.3s;
+  -ms-animation-delay: 0.3s;
+  -webkit-animation-delay: 0.3s;
+  -moz-animation-delay: 0.3s;
+}
+
+.windows8 #wBall_3 {
+  animation-delay: 0.61s;
+  -o-animation-delay: 0.61s;
+  -ms-animation-delay: 0.61s;
+  -webkit-animation-delay: 0.61s;
+  -moz-animation-delay: 0.61s;
+}
+
+.windows8 #wBall_4 {
+  animation-delay: 0.91s;
+  -o-animation-delay: 0.91s;
+  -ms-animation-delay: 0.91s;
+  -webkit-animation-delay: 0.91s;
+  -moz-animation-delay: 0.91s;
+}
+
+.windows8 #wBall_5 {
+  animation-delay: 1.22s;
+  -o-animation-delay: 1.22s;
+  -ms-animation-delay: 1.22s;
+  -webkit-animation-delay: 1.22s;
+  -moz-animation-delay: 1.22s;
+}
+
+@keyframes orbit {
+  0% {
+    opacity: 1;
+    z-index: 99;
+    transform: rotate(180deg);
+    animation-timing-function: ease-out;
+  }
+
+  7% {
+    opacity: 1;
+    transform: rotate(300deg);
+    animation-timing-function: linear;
+    origin: 0%;
+  }
+
+  30% {
+    opacity: 1;
+    transform: rotate(410deg);
+    animation-timing-function: ease-in-out;
+    origin: 7%;
+  }
+
+  39% {
+    opacity: 1;
+    transform: rotate(645deg);
+    animation-timing-function: linear;
+    origin: 30%;
+  }
+
+  70% {
+    opacity: 1;
+    transform: rotate(770deg);
+    animation-timing-function: ease-out;
+    origin: 39%;
+  }
+
+  75% {
+    opacity: 1;
+    transform: rotate(900deg);
+    animation-timing-function: ease-out;
+    origin: 70%;
+  }
+
+  76% {
+    opacity: 0;
+    transform: rotate(900deg);
+  }
+
+  100% {
+    opacity: 0;
+    transform: rotate(900deg);
+  }
+}
+
+// @keyframes orbit {
+// 	0% {
+// 		opacity: 1;
+// 		z-index:99;
+// 		transform: rotate(180deg);
+// 		animation-timing-function: ease-out;
+// 	}
+
+// 	10% {
+// 		opacity: 1;
+// 		transform: rotate(300deg);
+// 		animation-timing-function: linear;
+// 		origin:0%;
+// 	}
+
+// 	40% {
+// 		opacity: 1;
+// 		transform:rotate(410deg);
+// 		animation-timing-function: ease-in-out;
+// 		origin:7%;
+// 	}
+
+// 	55% {
+// 		opacity: 1;
+// 		transform: rotate(645deg);
+// 		animation-timing-function: linear;
+// 		origin:30%;
+// 	}
+
+// 	65% {
+// 		opacity: 1;
+// 		transform: rotate(770deg);
+// 		animation-timing-function: ease-out;
+// 		origin:39%;
+// 	}
+
+//   95% {
+// 		opacity: 1;
+// 		transform: rotate(890deg);
+// 		animation-timing-function: linear;
+// 		origin:30%;
+// 	}
+
+// 76% {
+// 	opacity: 1;
+// 	transform:rotate(900deg);
+// }
+
+// 	100% {
+// 		opacity: 1;
+// 		transform: rotate(900deg);
+// 	}
+// }
+
+@-o-keyframes orbit {
+  0% {
+    opacity: 1;
+    z-index: 99;
+    -o-transform: rotate(180deg);
+    -o-animation-timing-function: ease-out;
+  }
+
+  7% {
+    opacity: 1;
+    -o-transform: rotate(300deg);
+    -o-animation-timing-function: linear;
+    -o-origin: 0%;
+  }
+
+  30% {
+    opacity: 1;
+    -o-transform: rotate(410deg);
+    -o-animation-timing-function: ease-in-out;
+    -o-origin: 7%;
+  }
+
+  39% {
+    opacity: 1;
+    -o-transform: rotate(645deg);
+    -o-animation-timing-function: linear;
+    -o-origin: 30%;
+  }
+
+  70% {
+    opacity: 1;
+    -o-transform: rotate(770deg);
+    -o-animation-timing-function: ease-out;
+    -o-origin: 39%;
+  }
+
+  75% {
+    opacity: 1;
+    -o-transform: rotate(900deg);
+    -o-animation-timing-function: ease-out;
+    -o-origin: 70%;
+  }
+
+  76% {
+    opacity: 0;
+    -o-transform: rotate(900deg);
+  }
+
+  100% {
+    opacity: 0;
+    -o-transform: rotate(900deg);
+  }
+}
+
+@-ms-keyframes orbit {
+  0% {
+    opacity: 1;
+    z-index: 99;
+    -ms-transform: rotate(180deg);
+    -ms-animation-timing-function: ease-out;
+  }
+
+  7% {
+    opacity: 1;
+    -ms-transform: rotate(300deg);
+    -ms-animation-timing-function: linear;
+    -ms-origin: 0%;
+  }
+
+  30% {
+    opacity: 1;
+    -ms-transform: rotate(410deg);
+    -ms-animation-timing-function: ease-in-out;
+    -ms-origin: 7%;
+  }
+
+  39% {
+    opacity: 1;
+    -ms-transform: rotate(645deg);
+    -ms-animation-timing-function: linear;
+    -ms-origin: 30%;
+  }
+
+  70% {
+    opacity: 1;
+    -ms-transform: rotate(770deg);
+    -ms-animation-timing-function: ease-out;
+    -ms-origin: 39%;
+  }
+
+  75% {
+    opacity: 1;
+    -ms-transform: rotate(900deg);
+    -ms-animation-timing-function: ease-out;
+    -ms-origin: 70%;
+  }
+
+  76% {
+    opacity: 0;
+    -ms-transform: rotate(900deg);
+  }
+
+  100% {
+    opacity: 0;
+    -ms-transform: rotate(900deg);
+  }
+}
+
+@-webkit-keyframes orbit {
+  0% {
+    opacity: 1;
+    z-index: 99;
+    -webkit-transform: rotate(180deg);
+    -webkit-animation-timing-function: ease-out;
+  }
+
+  7% {
+    opacity: 1;
+    -webkit-transform: rotate(300deg);
+    -webkit-animation-timing-function: linear;
+    -webkit-origin: 0%;
+  }
+
+  30% {
+    opacity: 1;
+    -webkit-transform: rotate(410deg);
+    -webkit-animation-timing-function: ease-in-out;
+    -webkit-origin: 7%;
+  }
+
+  39% {
+    opacity: 1;
+    -webkit-transform: rotate(645deg);
+    -webkit-animation-timing-function: linear;
+    -webkit-origin: 30%;
+  }
+
+  70% {
+    opacity: 1;
+    -webkit-transform: rotate(770deg);
+    -webkit-animation-timing-function: ease-out;
+    -webkit-origin: 39%;
+  }
+
+  75% {
+    opacity: 1;
+    -webkit-transform: rotate(900deg);
+    -webkit-animation-timing-function: ease-out;
+    -webkit-origin: 70%;
+  }
+
+  76% {
+    opacity: 0;
+    -webkit-transform: rotate(900deg);
+  }
+
+  100% {
+    opacity: 0;
+    -webkit-transform: rotate(900deg);
+  }
+}
+
+@-moz-keyframes orbit {
+  0% {
+    opacity: 1;
+    z-index: 99;
+    -moz-transform: rotate(180deg);
+    -moz-animation-timing-function: ease-out;
+  }
+
+  7% {
+    opacity: 1;
+    -moz-transform: rotate(300deg);
+    -moz-animation-timing-function: linear;
+    -moz-origin: 0%;
+  }
+
+  30% {
+    opacity: 1;
+    -moz-transform: rotate(410deg);
+    -moz-animation-timing-function: ease-in-out;
+    -moz-origin: 7%;
+  }
+
+  39% {
+    opacity: 1;
+    -moz-transform: rotate(645deg);
+    -moz-animation-timing-function: linear;
+    -moz-origin: 30%;
+  }
+
+  70% {
+    opacity: 1;
+    -moz-transform: rotate(770deg);
+    -moz-animation-timing-function: ease-out;
+    -moz-origin: 39%;
+  }
+
+  75% {
+    opacity: 1;
+    -moz-transform: rotate(900deg);
+    -moz-animation-timing-function: ease-out;
+    -moz-origin: 70%;
+  }
+
+  76% {
+    opacity: 0;
+    -moz-transform: rotate(900deg);
+  }
+
+  100% {
+    opacity: 0;
+    -moz-transform: rotate(900deg);
+  }
+}

--- a/src/renderer/styles/TextInput.scss
+++ b/src/renderer/styles/TextInput.scss
@@ -1,6 +1,6 @@
 @import 'color';
 @import 'spacing';
-.textInput {
+.text-input {
   background: $primary-dark;
   color: $white;
   border: solid $spacing-xxs $secondary-default;

--- a/src/renderer/styles/_constant.scss
+++ b/src/renderer/styles/_constant.scss
@@ -1,5 +1,3 @@
-$content-width: 100%;
-$side-bar-width: 150px;
 $preset-bar-width: 328px;
 $title-bar-height: 28px;
 
@@ -7,3 +5,6 @@ $band-height: 498px;
 $band-width: 64px;
 
 $equalizer-height: 580px;
+
+// NumberInput
+$input-height: 24px;

--- a/src/renderer/styles/_constant.scss
+++ b/src/renderer/styles/_constant.scss
@@ -1,7 +1,7 @@
 $content-width: 100%;
-$sidebar-width: 150px;
-$presetbar-width: 328px;
-$titlebar-height: 28px;
+$side-bar-width: 150px;
+$preset-bar-width: 328px;
+$title-bar-height: 28px;
 
 $band-height: 498px;
 $band-width: 64px;

--- a/src/renderer/styles/_constant.scss
+++ b/src/renderer/styles/_constant.scss
@@ -1,4 +1,5 @@
 $preset-bar-width: 328px;
+$sidebar-width: 150px;
 $title-bar-height: 28px;
 
 $band-height: 498px;

--- a/src/renderer/widgets/NumberInput.tsx
+++ b/src/renderer/widgets/NumberInput.tsx
@@ -245,11 +245,11 @@ const NumberInput = ({
   return (
     <label
       htmlFor={name}
-      className="numberInput"
+      className="number-input"
       // the ch unit supposedly uses the '0' as the per character valueLength
       style={{ '--input-width': `${valueLength}ch` } as CSSProperties}
     >
-      <div className="inputWrapper row center">
+      <div className="input-wrapper row center">
         <input
           ref={inputRef}
           type="text"

--- a/src/renderer/widgets/TextInput.tsx
+++ b/src/renderer/widgets/TextInput.tsx
@@ -56,7 +56,7 @@ const TextInput = forwardRef(
     return (
       <input
         ref={ref}
-        className="textInput"
+        className="text-input"
         type="text"
         value={storedValue}
         aria-label={ariaLabel}


### PR DESCRIPTION
# Summary
Move loading state to individual subsections for a better UX.

Note: Pointing this PR at jat-30 for now. Will perform the necessary rebase / clean up necessary once [jat-30](https://github.com/h39s/AQUA/pull/31) is merged.

## Changes
- Add `Spinner` component using css to animate
- Add loading state to each subsection and remove global one

## Refactor
- Rename scss classes to use kebab case for consistency
- Change overall app layout to use a grid layout for better control and less clutter of elements and class names

## Screenshot
<img width="1070" alt="image" src="https://user-images.githubusercontent.com/30204513/214479818-b51ae504-8880-4d06-9fb5-ef49c23be56e.png">
