### PR TITLE
JAT-97 Preset is always set to 0dB on refresh

### DIFF
--- a/src/renderer/graph/FrequencyResponseChart.tsx
+++ b/src/renderer/graph/FrequencyResponseChart.tsx
@@ -31,8 +31,14 @@ interface IGraphData {
 }
 
 const FrequencyResponseChart = () => {
-  const { filters, preAmp, isAutoPreAmpOn, setPreAmp, isGraphViewOn } =
-    useAquaContext();
+  const {
+    filters,
+    isAutoPreAmpOn,
+    isLoading,
+    preAmp,
+    setPreAmp,
+    isGraphViewOn,
+  } = useAquaContext();
   const prevFilters = useRef<IFilter[]>([]);
   const prevFilterLines = useRef<IChartLineDataPointsById>({});
 
@@ -132,11 +138,12 @@ const FrequencyResponseChart = () => {
   }, [filters, preAmp]);
 
   useEffect(() => {
-    if (isAutoPreAmpOn) {
+    // Don't automatically adjust preamp if state hasn't been fetched yet
+    if (!isLoading && isAutoPreAmpOn) {
       setMainPreAmp(autoPreAmpValue);
       setPreAmp(autoPreAmpValue);
     }
-  }, [autoPreAmpValue, isAutoPreAmpOn, setPreAmp]);
+  }, [autoPreAmpValue, isAutoPreAmpOn, isLoading, setPreAmp]);
 
   const dimensions: ChartDimensions = {
     width: 988,


### PR DESCRIPTION
## Root cause
This bug was due to the auto preamp code trying to adjust the preamp before the state had been fetched from the backend. Since the default state requires no preamp adjustment, the UI tries to write 0dB to the aqua configuration. As a side effect, an additional `aqua.txt` file would be created in the root folder of the app (that isn't actually used). 

## Solution
Add a check that the app is not in the loading state before automatically adjusting the preamp.