### PR TITLE
JAT-100 Resizing of the app window

### DIFF
--- a/src/__tests__/unit_tests/RangeInput.test.tsx
+++ b/src/__tests__/unit_tests/RangeInput.test.tsx
@@ -125,7 +125,7 @@ describe('RangeInput', () => {
         max={5}
         handleChange={handleChange}
         handleMouseUp={handleMouseUp}
-        width={150}
+        height="150px"
         value={testValue}
         isDisabled={false}
       />
@@ -144,7 +144,7 @@ describe('RangeInput', () => {
         max={5}
         handleChange={handleChange}
         handleMouseUp={handleMouseUp}
-        width={150}
+        height="150px"
         value={testValue}
         isDisabled={false}
       />

--- a/src/__tests__/unit_tests/RangeInput.test.tsx
+++ b/src/__tests__/unit_tests/RangeInput.test.tsx
@@ -22,7 +22,7 @@ describe('RangeInput', () => {
         max={5}
         handleChange={handleChange}
         handleMouseUp={handleMouseUp}
-        width={150}
+        height="150px"
         value={testValue}
         isDisabled={false}
       />
@@ -39,7 +39,7 @@ describe('RangeInput', () => {
         max={5}
         handleChange={handleChange}
         handleMouseUp={handleMouseUp}
-        width={150}
+        height="150px"
         value={testValue}
         isDisabled={false}
       />
@@ -63,7 +63,7 @@ describe('RangeInput', () => {
         max={5}
         handleChange={handleChange}
         handleMouseUp={handleMouseUp}
-        width={150}
+        height="150px"
         value={testValue}
         isDisabled={false}
       />
@@ -87,7 +87,7 @@ describe('RangeInput', () => {
         max={5}
         handleChange={handleChange}
         handleMouseUp={handleMouseUp}
-        width={150}
+        height="150px"
         value={testValue}
         isDisabled={false}
       />
@@ -106,7 +106,7 @@ describe('RangeInput', () => {
         max={5}
         handleChange={handleChange}
         handleMouseUp={handleMouseUp}
-        width={150}
+        height="150px"
         value={testValue}
         isDisabled={false}
       />
@@ -163,7 +163,7 @@ describe('RangeInput', () => {
         max={5}
         handleChange={handleChange}
         handleMouseUp={handleMouseUp}
-        width={150}
+        height="150px"
         value={testValue}
         isDisabled={false}
         incrementPrecision={1}
@@ -184,7 +184,7 @@ describe('RangeInput', () => {
         max={5}
         handleChange={handleChange}
         handleMouseUp={handleMouseUp}
-        width={150}
+        height="150px"
         value={testValue}
         isDisabled={false}
         incrementPrecision={0}
@@ -205,7 +205,7 @@ describe('RangeInput', () => {
         max={5}
         handleChange={handleChange}
         handleMouseUp={handleMouseUp}
-        width={150}
+        height="150px"
         value={testValue}
         isDisabled
       />

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -99,7 +99,7 @@ export const getDefaultState = (): IState => {
   return {
     isEnabled: true,
     isAutoPreAmpOn: true,
-    isGraphViewOn: true,
+    isGraphViewOn: true, // true as default so that spinner can be seen on initial load
     preAmp: 0,
     filters: getDefaultFilters(),
   };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -69,7 +69,6 @@ const setWindowDimension = (isExpanded: boolean) => {
     const currHeight = mainWindow.getSize()[1] - 2;
     if (isExpanded) {
       mainWindow.setMinimumSize(WINDOW_WIDTH, WINDOW_HEIGHT_EXPANDED);
-      // TODO: decide if this change is worth it or not
       mainWindow.setSize(
         currWidth,
         Math.max(currHeight, WINDOW_HEIGHT_EXPANDED)

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -66,12 +66,20 @@ const setWindowDimension = (isExpanded: boolean) => {
   if (mainWindow) {
     // The "-2" is necessary because otherwise the width will progressively keep increasing by 2
     const currWidth = mainWindow.getSize()[0] - 2;
+    const currHeight = mainWindow.getSize()[1] - 2;
     if (isExpanded) {
       mainWindow.setMinimumSize(WINDOW_WIDTH, WINDOW_HEIGHT_EXPANDED);
-      mainWindow.setSize(currWidth, WINDOW_HEIGHT_EXPANDED);
+      // TODO: decide if this change is worth it or not
+      mainWindow.setSize(
+        currWidth,
+        Math.min(currHeight, WINDOW_HEIGHT_EXPANDED)
+      );
     } else {
       mainWindow.setMinimumSize(WINDOW_WIDTH, WINDOW_HEIGHT);
-      mainWindow.setSize(currWidth, WINDOW_HEIGHT);
+      mainWindow.setSize(
+        currWidth,
+        Math.min(currHeight, WINDOW_HEIGHT_EXPANDED)
+      );
     }
   }
 };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -64,14 +64,14 @@ let mainWindow: BrowserWindow | null = null;
 
 const setWindowDimension = (isExpanded: boolean) => {
   if (mainWindow) {
+    // The "-2" is necessary because otherwise the width will progressively keep increasing by 2
+    const currWidth = mainWindow.getSize()[0] - 2;
     if (isExpanded) {
-      mainWindow.setMaximumSize(WINDOW_WIDTH, WINDOW_HEIGHT_EXPANDED);
-      mainWindow.setSize(WINDOW_WIDTH, WINDOW_HEIGHT_EXPANDED);
       mainWindow.setMinimumSize(WINDOW_WIDTH, WINDOW_HEIGHT_EXPANDED);
+      mainWindow.setSize(currWidth, WINDOW_HEIGHT_EXPANDED);
     } else {
       mainWindow.setMinimumSize(WINDOW_WIDTH, WINDOW_HEIGHT);
-      mainWindow.setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
-      mainWindow.setMaximumSize(WINDOW_WIDTH, WINDOW_HEIGHT);
+      mainWindow.setSize(currWidth, WINDOW_HEIGHT);
     }
   }
 };
@@ -595,12 +595,10 @@ const createMainWindow = async () => {
     show: false,
     width: WINDOW_WIDTH,
     minWidth: WINDOW_WIDTH,
-    maxWidth: WINDOW_WIDTH,
     height: WINDOW_HEIGHT,
     minHeight: WINDOW_HEIGHT,
-    maxHeight: WINDOW_HEIGHT,
     icon: getAssetPath('icon.png'),
-    resizable: false,
+    resizable: true,
     webPreferences: {
       preload: app.isPackaged
         ? path.join(__dirname, 'preload.js')

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -72,14 +72,11 @@ const setWindowDimension = (isExpanded: boolean) => {
       // TODO: decide if this change is worth it or not
       mainWindow.setSize(
         currWidth,
-        Math.min(currHeight, WINDOW_HEIGHT_EXPANDED)
+        Math.max(currHeight, WINDOW_HEIGHT_EXPANDED)
       );
     } else {
       mainWindow.setMinimumSize(WINDOW_WIDTH, WINDOW_HEIGHT);
-      mainWindow.setSize(
-        currWidth,
-        Math.min(currHeight, WINDOW_HEIGHT_EXPANDED)
-      );
+      mainWindow.setSize(currWidth, WINDOW_HEIGHT);
     }
   }
 };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,53 +1,22 @@
 import { MemoryRouter as Router, Routes, Route } from 'react-router-dom';
 import './styles/App.scss';
-import { useLayoutEffect, useRef, useState } from 'react';
 import MainContent from './MainContent';
 import { AquaProvider, useAquaContext } from './utils/AquaContext';
 import PrereqMissingModal from './PrereqMissingModal';
 import SideBar from './SideBar';
 import FrequencyResponseChart from './graph/FrequencyResponseChart';
 import PresetsBar from './PresetsBar';
-import { useThrottle } from './utils/utils';
 
 const AppContent = () => {
   const { isGraphViewOn, isLoading, globalError, performHealthCheck } =
     useAquaContext();
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  const [height, setHeight] = useState<number>(566);
-
-  const updateDimensions = () => {
-    const newHeight = wrapperRef.current?.clientHeight;
-    if (newHeight && newHeight > 0) {
-      setHeight(newHeight);
-    }
-  };
-
-  const throttledDimensions = useThrottle(() => {
-    const newHeight = wrapperRef.current?.clientHeight;
-    if (newHeight && newHeight > 0) {
-      setHeight(newHeight);
-    }
-  }, 100);
-
-  useLayoutEffect(() => {
-    // Compute dimensions on initial render
-    updateDimensions();
-    window.addEventListener('resize', throttledDimensions);
-    return () => window.removeEventListener('resize', throttledDimensions);
-  }, [throttledDimensions]);
-
-  useLayoutEffect(() => {
-    // Update layout measurements when graph view is toggled
-    updateDimensions();
-  }, [isGraphViewOn]);
 
   return (
     <>
-      <SideBar height={height} />
-      <MainContent ref={wrapperRef} height={height} />
+      <SideBar />
+      <MainContent />
       <PresetsBar />
-      <FrequencyResponseChart />
+      {isGraphViewOn && <FrequencyResponseChart />}
       {globalError && (
         <PrereqMissingModal
           isLoading={isLoading}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,19 +1,51 @@
 import { MemoryRouter as Router, Routes, Route } from 'react-router-dom';
 import './styles/App.scss';
+import { useLayoutEffect, useRef, useState } from 'react';
 import MainContent from './MainContent';
 import { AquaProvider, useAquaContext } from './utils/AquaContext';
 import PrereqMissingModal from './PrereqMissingModal';
 import SideBar from './SideBar';
 import FrequencyResponseChart from './graph/FrequencyResponseChart';
 import PresetsBar from './PresetsBar';
+import { useThrottle } from './utils/utils';
 
 const AppContent = () => {
-  const { isLoading, globalError, performHealthCheck } = useAquaContext();
+  const { isGraphViewOn, isLoading, globalError, performHealthCheck } =
+    useAquaContext();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const [height, setHeight] = useState<number>(566);
+
+  const updateDimensions = () => {
+    const newHeight = wrapperRef.current?.clientHeight;
+    if (newHeight && newHeight > 0) {
+      setHeight(newHeight);
+    }
+  };
+
+  const throttledDimensions = useThrottle(() => {
+    const newHeight = wrapperRef.current?.clientHeight;
+    if (newHeight && newHeight > 0) {
+      setHeight(newHeight);
+    }
+  }, 100);
+
+  useLayoutEffect(() => {
+    // Compute dimensions on initial render
+    updateDimensions();
+    window.addEventListener('resize', throttledDimensions);
+    return () => window.removeEventListener('resize', throttledDimensions);
+  }, [throttledDimensions]);
+
+  useLayoutEffect(() => {
+    // Update layout measurements when graph view is toggled
+    updateDimensions();
+  }, [isGraphViewOn]);
 
   return (
     <>
-      <SideBar />
-      <MainContent />
+      <SideBar height={height} />
+      <MainContent ref={wrapperRef} height={height} />
       <PresetsBar />
       <FrequencyResponseChart />
       {globalError && (

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -8,15 +8,14 @@ import FrequencyResponseChart from './graph/FrequencyResponseChart';
 import PresetsBar from './PresetsBar';
 
 const AppContent = () => {
-  const { isGraphViewOn, isLoading, globalError, performHealthCheck } =
-    useAquaContext();
+  const { isLoading, globalError, performHealthCheck } = useAquaContext();
 
   return (
     <>
       <SideBar />
       <MainContent />
       <PresetsBar />
-      {isGraphViewOn && <FrequencyResponseChart />}
+      <FrequencyResponseChart />
       {globalError && (
         <PrereqMissingModal
           isLoading={isLoading}

--- a/src/renderer/MainContent.tsx
+++ b/src/renderer/MainContent.tsx
@@ -1,4 +1,11 @@
-import { Fragment, useMemo } from 'react';
+import {
+  CSSProperties,
+  ForwardedRef,
+  forwardRef,
+  Fragment,
+  useMemo,
+  useRef,
+} from 'react';
 import { MAX_NUM_FILTERS, MIN_NUM_FILTERS } from 'common/constants';
 import FrequencyBand from './components/FrequencyBand';
 import { useAquaContext } from './utils/AquaContext';
@@ -6,81 +13,104 @@ import './styles/MainContent.scss';
 import AddSliderDivider from './components/AddSliderDivider';
 import Spinner from './icons/Spinner';
 
-const MainContent = () => {
-  const { filters: freqSortedFilters, isLoading } = useAquaContext();
+const MainContent = forwardRef(
+  ({ height }: { height: number }, ref: ForwardedRef<HTMLDivElement>) => {
+    const bandsWrapperRef = useRef<HTMLDivElement>(null);
+    const { filters: freqSortedFilters, isLoading } = useAquaContext();
 
-  // Store widths for AddSliderDividers and FrequencyBands so we can manually position them
-  const DIVIDER_WIDTH = 28;
-  const BAND_WIDTH = 72.94;
+    // Store widths for AddSliderDividers and FrequencyBands so we can manually position them
+    const DIVIDER_WIDTH = 28;
+    const BAND_WIDTH = 72.94;
 
-  const [idSortedFilters, sortIndexMap] = useMemo(() => {
-    // Obtain a fixed order list of the filters
-    const fixedSort = freqSortedFilters
-      .slice()
-      .sort((a, b) => a.id.localeCompare(b.id));
+    const [idSortedFilters, sortIndexMap] = useMemo(() => {
+      // Obtain a fixed order list of the filters
+      const fixedSort = freqSortedFilters
+        .slice()
+        .sort((a, b) => a.id.localeCompare(b.id));
 
-    // Compute a mapping from a filter id to its sorted index
-    const map: { [key: string]: number } = {};
-    freqSortedFilters.forEach((f, index) => {
-      map[f.id] = index;
-    });
+      // Compute a mapping from a filter id to its sorted index
+      const map: { [key: string]: number } = {};
+      freqSortedFilters.forEach((f, index) => {
+        map[f.id] = index;
+      });
 
-    return [fixedSort, map];
-  }, [freqSortedFilters]);
+      return [fixedSort, map];
+    }, [freqSortedFilters]);
 
-  return isLoading ? (
-    <div className="center full row">
-      <Spinner />
-    </div>
-  ) : (
-    <div className="center main-content">
-      <div className="col center band-label">
-        <span className="row-label">Filter Type</span>
-        <span className="row-label">Frequency (Hz)</span>
-        <div className="col">
+    const sliderHeight = useMemo(
+      // TODO: improve comments here
+      () => height - 5 * 8 - 30 - 36 * 3 - 60 - 2 * 4 - 2 * 23,
+      [height]
+    );
+
+    return isLoading ? (
+      <div className="center full row">
+        <Spinner />
+      </div>
+    ) : (
+      <div
+        ref={ref}
+        className="center main-content"
+        style={
+          // Set css variables for determining upper/lower track
+          {
+            '--slider-height': sliderHeight,
+          } as CSSProperties
+        }
+      >
+        <div className="col center band-label">
+          <span />
+          <span className="row-label">Filter Type</span>
+          <span className="row-label">Frequency (Hz)</span>
+          <span />
           <span>+30dB</span>
+          <span />
           <span>0dB</span>
+          <span />
           <span>-30dB</span>
+          <span />
+          <span className="row-label">Gain (dB)</span>
+          <span className="row-label">Quality</span>
+          <span />
         </div>
-        <span className="row-label">Gain (dB)</span>
-        <span className="row-label">Quality</span>
+        <div ref={bandsWrapperRef} className="bands row center">
+          <AddSliderDivider
+            sliderIndex={-1}
+            isMaxSliderCount={idSortedFilters.length >= MAX_NUM_FILTERS}
+          />
+          {idSortedFilters.map((filter) => {
+            const sliderIndex = sortIndexMap[filter.id];
+            return (
+              <Fragment key={`slider-${filter.id}`}>
+                <FrequencyBand
+                  sliderIndex={sliderIndex}
+                  filter={filter}
+                  isMinSliderCount={idSortedFilters.length <= MIN_NUM_FILTERS}
+                  sliderHeight={sliderHeight}
+                  // Manually position the frequency band
+                  style={{
+                    transform: `translateX(${
+                      DIVIDER_WIDTH + sliderIndex * (DIVIDER_WIDTH + BAND_WIDTH)
+                    }px)`,
+                  }}
+                />
+                <AddSliderDivider
+                  sliderIndex={sliderIndex}
+                  isMaxSliderCount={idSortedFilters.length >= MAX_NUM_FILTERS}
+                  // Manually position the divider
+                  style={{
+                    transform: `translateX(${
+                      (sliderIndex + 1) * (DIVIDER_WIDTH + BAND_WIDTH)
+                    }px)`,
+                  }}
+                />
+              </Fragment>
+            );
+          })}
+        </div>
       </div>
-      <div className="bands row center">
-        <AddSliderDivider
-          sliderIndex={-1}
-          isMaxSliderCount={idSortedFilters.length >= MAX_NUM_FILTERS}
-        />
-        {idSortedFilters.map((filter) => {
-          const sliderIndex = sortIndexMap[filter.id];
-          return (
-            <Fragment key={`slider-${filter.id}`}>
-              <FrequencyBand
-                sliderIndex={sliderIndex}
-                filter={filter}
-                isMinSliderCount={idSortedFilters.length <= MIN_NUM_FILTERS}
-                // Manually position the frequency band
-                style={{
-                  transform: `translateX(${
-                    DIVIDER_WIDTH + sliderIndex * (DIVIDER_WIDTH + BAND_WIDTH)
-                  }px)`,
-                }}
-              />
-              <AddSliderDivider
-                sliderIndex={sliderIndex}
-                isMaxSliderCount={idSortedFilters.length >= MAX_NUM_FILTERS}
-                // Manually position the divider
-                style={{
-                  transform: `translateX(${
-                    (sliderIndex + 1) * (DIVIDER_WIDTH + BAND_WIDTH)
-                  }px)`,
-                }}
-              />
-            </Fragment>
-          );
-        })}
-      </div>
-    </div>
-  );
-};
+    );
+  }
+);
 
 export default MainContent;

--- a/src/renderer/MainContent.tsx
+++ b/src/renderer/MainContent.tsx
@@ -1,11 +1,4 @@
-import {
-  CSSProperties,
-  ForwardedRef,
-  forwardRef,
-  Fragment,
-  useMemo,
-  useRef,
-} from 'react';
+import { Fragment, useMemo } from 'react';
 import { MAX_NUM_FILTERS, MIN_NUM_FILTERS } from 'common/constants';
 import FrequencyBand from './components/FrequencyBand';
 import { useAquaContext } from './utils/AquaContext';
@@ -13,104 +6,85 @@ import './styles/MainContent.scss';
 import AddSliderDivider from './components/AddSliderDivider';
 import Spinner from './icons/Spinner';
 
-const MainContent = forwardRef(
-  ({ height }: { height: number }, ref: ForwardedRef<HTMLDivElement>) => {
-    const bandsWrapperRef = useRef<HTMLDivElement>(null);
-    const { filters: freqSortedFilters, isLoading } = useAquaContext();
+const MainContent = () => {
+  const { filters: freqSortedFilters, isLoading } = useAquaContext();
 
-    // Store widths for AddSliderDividers and FrequencyBands so we can manually position them
-    const DIVIDER_WIDTH = 28;
-    const BAND_WIDTH = 72.94;
+  // Store widths for AddSliderDividers and FrequencyBands so we can manually position them
+  const DIVIDER_WIDTH = 28;
+  const BAND_WIDTH = 72.94;
 
-    const [idSortedFilters, sortIndexMap] = useMemo(() => {
-      // Obtain a fixed order list of the filters
-      const fixedSort = freqSortedFilters
-        .slice()
-        .sort((a, b) => a.id.localeCompare(b.id));
+  const [idSortedFilters, sortIndexMap] = useMemo(() => {
+    // Obtain a fixed order list of the filters
+    const fixedSort = freqSortedFilters
+      .slice()
+      .sort((a, b) => a.id.localeCompare(b.id));
 
-      // Compute a mapping from a filter id to its sorted index
-      const map: { [key: string]: number } = {};
-      freqSortedFilters.forEach((f, index) => {
-        map[f.id] = index;
-      });
+    // Compute a mapping from a filter id to its sorted index
+    const map: { [key: string]: number } = {};
+    freqSortedFilters.forEach((f, index) => {
+      map[f.id] = index;
+    });
 
-      return [fixedSort, map];
-    }, [freqSortedFilters]);
+    return [fixedSort, map];
+  }, [freqSortedFilters]);
 
-    const sliderHeight = useMemo(
-      // TODO: improve comments here
-      () => height - 5 * 8 - 30 - 36 * 3 - 60 - 2 * 4 - 2 * 23,
-      [height]
-    );
-
-    return isLoading ? (
-      <div className="center full row">
-        <Spinner />
+  return isLoading ? (
+    <div className="center full row">
+      <Spinner />
+    </div>
+  ) : (
+    <div className="center main-content">
+      <div className="col center band-label">
+        <span />
+        <span className="row-label">Filter Type</span>
+        <span className="row-label">Frequency (Hz)</span>
+        <span />
+        <span>+30dB</span>
+        <span />
+        <span>0dB</span>
+        <span />
+        <span>-30dB</span>
+        <span />
+        <span className="row-label">Gain (dB)</span>
+        <span className="row-label">Quality</span>
+        <span />
       </div>
-    ) : (
-      <div
-        ref={ref}
-        className="center main-content"
-        style={
-          // Set css variables for determining upper/lower track
-          {
-            '--slider-height': sliderHeight,
-          } as CSSProperties
-        }
-      >
-        <div className="col center band-label">
-          <span />
-          <span className="row-label">Filter Type</span>
-          <span className="row-label">Frequency (Hz)</span>
-          <span />
-          <span>+30dB</span>
-          <span />
-          <span>0dB</span>
-          <span />
-          <span>-30dB</span>
-          <span />
-          <span className="row-label">Gain (dB)</span>
-          <span className="row-label">Quality</span>
-          <span />
-        </div>
-        <div ref={bandsWrapperRef} className="bands row center">
-          <AddSliderDivider
-            sliderIndex={-1}
-            isMaxSliderCount={idSortedFilters.length >= MAX_NUM_FILTERS}
-          />
-          {idSortedFilters.map((filter) => {
-            const sliderIndex = sortIndexMap[filter.id];
-            return (
-              <Fragment key={`slider-${filter.id}`}>
-                <FrequencyBand
-                  sliderIndex={sliderIndex}
-                  filter={filter}
-                  isMinSliderCount={idSortedFilters.length <= MIN_NUM_FILTERS}
-                  sliderHeight={sliderHeight}
-                  // Manually position the frequency band
-                  style={{
-                    transform: `translateX(${
-                      DIVIDER_WIDTH + sliderIndex * (DIVIDER_WIDTH + BAND_WIDTH)
-                    }px)`,
-                  }}
-                />
-                <AddSliderDivider
-                  sliderIndex={sliderIndex}
-                  isMaxSliderCount={idSortedFilters.length >= MAX_NUM_FILTERS}
-                  // Manually position the divider
-                  style={{
-                    transform: `translateX(${
-                      (sliderIndex + 1) * (DIVIDER_WIDTH + BAND_WIDTH)
-                    }px)`,
-                  }}
-                />
-              </Fragment>
-            );
-          })}
-        </div>
+      <div className="bands row center">
+        <AddSliderDivider
+          sliderIndex={-1}
+          isMaxSliderCount={idSortedFilters.length >= MAX_NUM_FILTERS}
+        />
+        {idSortedFilters.map((filter) => {
+          const sliderIndex = sortIndexMap[filter.id];
+          return (
+            <Fragment key={`slider-${filter.id}`}>
+              <FrequencyBand
+                sliderIndex={sliderIndex}
+                filter={filter}
+                isMinSliderCount={idSortedFilters.length <= MIN_NUM_FILTERS}
+                // Manually position the frequency band
+                style={{
+                  transform: `translateX(${
+                    DIVIDER_WIDTH + sliderIndex * (DIVIDER_WIDTH + BAND_WIDTH)
+                  }px)`,
+                }}
+              />
+              <AddSliderDivider
+                sliderIndex={sliderIndex}
+                isMaxSliderCount={idSortedFilters.length >= MAX_NUM_FILTERS}
+                // Manually position the divider
+                style={{
+                  transform: `translateX(${
+                    (sliderIndex + 1) * (DIVIDER_WIDTH + BAND_WIDTH)
+                  }px)`,
+                }}
+              />
+            </Fragment>
+          );
+        })}
       </div>
-    );
-  }
-);
+    </div>
+  );
+};
 
 export default MainContent;

--- a/src/renderer/SideBar.tsx
+++ b/src/renderer/SideBar.tsx
@@ -1,5 +1,5 @@
 import { ErrorDescription } from 'common/errors';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { disableAutoPreAmp, setMainPreAmp } from './utils/equalizerApi';
 import EqualizerEnablerSwitch from './components/EqualizerEnablerSwitch';
 import Slider from './components/Slider';
@@ -9,28 +9,38 @@ import AutoPreAmpEnablerSwitch from './components/AutoPreAmpEnablerSwitch';
 import GraphViewSwitch from './components/GraphViewSwitch';
 import Spinner from './icons/Spinner';
 
-const SideBar = ({ height }: { height: number }) => {
+const SideBar = () => {
   const MIN = -30;
   const MAX = 30;
 
-  const { isLoading, preAmp, setGlobalError, setPreAmp, setAutoPreAmpOn } =
-    useAquaContext();
+  const {
+    isGraphViewOn,
+    isLoading,
+    preAmp,
+    setGlobalError,
+    setPreAmp,
+    setAutoPreAmpOn,
+  } = useAquaContext();
 
-  const setGain = async (newValue: number) => {
-    try {
-      setAutoPreAmpOn(false);
-      await disableAutoPreAmp();
-      await setMainPreAmp(newValue);
-      setPreAmp(newValue);
-    } catch (e) {
-      setGlobalError(e as ErrorDescription);
-    }
-  };
+  const setGain = useCallback(
+    async (newValue: number) => {
+      try {
+        setAutoPreAmpOn(false);
+        await disableAutoPreAmp();
+        await setMainPreAmp(newValue);
+        setPreAmp(newValue);
+      } catch (e) {
+        setGlobalError(e as ErrorDescription);
+      }
+    },
+    [setAutoPreAmpOn, setGlobalError, setPreAmp]
+  );
 
   const sliderHeight = useMemo(
     // TODO: improve comments here
-    () => height - 100 - 2 * 80 - 3 * 20 - 3 * 16 - 2 * 23 - 2 * 4 - 2 * 8 - 36,
-    [height]
+    // () => height - 100 - 2 * 80 - 3 * 20 - 3 * 16 - 2 * 23 - 2 * 4 - 2 * 8 - 36,
+    () => (isGraphViewOn ? '102px' : 'calc(100vh - 524px)'),
+    [isGraphViewOn]
   );
 
   return (

--- a/src/renderer/SideBar.tsx
+++ b/src/renderer/SideBar.tsx
@@ -1,4 +1,5 @@
 import { ErrorDescription } from 'common/errors';
+import { useMemo } from 'react';
 import { disableAutoPreAmp, setMainPreAmp } from './utils/equalizerApi';
 import EqualizerEnablerSwitch from './components/EqualizerEnablerSwitch';
 import Slider from './components/Slider';
@@ -8,7 +9,7 @@ import AutoPreAmpEnablerSwitch from './components/AutoPreAmpEnablerSwitch';
 import GraphViewSwitch from './components/GraphViewSwitch';
 import Spinner from './icons/Spinner';
 
-const SideBar = () => {
+const SideBar = ({ height }: { height: number }) => {
   const MIN = -30;
   const MAX = 30;
 
@@ -25,6 +26,12 @@ const SideBar = () => {
       setGlobalError(e as ErrorDescription);
     }
   };
+
+  const sliderHeight = useMemo(
+    // TODO: improve comments here
+    () => height - 100 - 2 * 80 - 3 * 20 - 3 * 16 - 2 * 23 - 2 * 4 - 2 * 8 - 36,
+    [height]
+  );
 
   return (
     <div className="col side-bar center">
@@ -46,7 +53,7 @@ const SideBar = () => {
               min={MIN}
               max={MAX}
               value={preAmp}
-              sliderHeight={110}
+              sliderHeight={sliderHeight}
               setValue={setGain}
               label="-30 dB"
             />

--- a/src/renderer/SideBar.tsx
+++ b/src/renderer/SideBar.tsx
@@ -37,8 +37,7 @@ const SideBar = () => {
   );
 
   const sliderHeight = useMemo(
-    // TODO: improve comments here
-    // () => height - 100 - 2 * 80 - 3 * 20 - 3 * 16 - 2 * 23 - 2 * 4 - 2 * 8 - 36,
+    // Manually determine slider height
     () => (isGraphViewOn ? '102px' : 'calc(100vh - 524px)'),
     [isGraphViewOn]
   );

--- a/src/renderer/components/FrequencyBand.tsx
+++ b/src/renderer/components/FrequencyBand.tsx
@@ -38,11 +38,18 @@ interface IFrequencyBandProps {
   filter: IFilter;
   isMinSliderCount: boolean;
   style?: CSSProperties;
+  sliderHeight: number;
 }
 
 const FrequencyBand = forwardRef(
   (
-    { sliderIndex, filter, isMinSliderCount, style }: IFrequencyBandProps,
+    {
+      sliderIndex,
+      filter,
+      isMinSliderCount,
+      sliderHeight,
+      style,
+    }: IFrequencyBandProps,
     ref: ForwardedRef<HTMLDivElement>
   ) => {
     const INTERVAL = 100;
@@ -188,7 +195,7 @@ const FrequencyBand = forwardRef(
               min={MIN_GAIN}
               max={MAX_GAIN}
               value={filter.gain}
-              sliderHeight={250}
+              sliderHeight={sliderHeight}
               setValue={handleGainSubmit}
             />
           </div>

--- a/src/renderer/components/GraphViewSwitch.tsx
+++ b/src/renderer/components/GraphViewSwitch.tsx
@@ -21,12 +21,17 @@ export default function GraphViewSwitch({ id }: IGraphViewSwitchProps) {
     try {
       if (isGraphViewOn) {
         await disableGraphView();
+
+        // Reduce window size before allowing parametric components to fill space
         await decreaseWindowSize();
+        setGraphViewOn(!isGraphViewOn);
       } else {
         await enableGraphView();
+
+        // Set parametric components to a fixed height before increasing window size
+        setGraphViewOn(!isGraphViewOn);
         await increaseWindowSize();
       }
-      setGraphViewOn(!isGraphViewOn);
     } catch (e) {
       setGlobalError(e as ErrorDescription);
     }

--- a/src/renderer/components/Slider.tsx
+++ b/src/renderer/components/Slider.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from 'react';
 import NumberInput from '../widgets/NumberInput';
 import RangeInput from '../widgets/RangeInput';
 import { useAquaContext } from '../utils/AquaContext';
-import { useThrottle } from '../utils/utils';
 import '../styles/Slider.scss';
 
 interface ISliderProps {
@@ -24,7 +23,6 @@ const Slider = ({
   label,
   setValue,
 }: ISliderProps) => {
-  const INTERVAL = 100;
   const { globalError } = useAquaContext();
 
   // Local copy of slider value used so that the number input increases smoothly while throttling EQ APO writes
@@ -47,18 +45,6 @@ const Slider = ({
     handleChangeValue(newValue);
   };
 
-  const throttledSetValue = useThrottle(handleChangeValue, INTERVAL);
-
-  // Helpers for adjusting the preAmp gain value
-  const handleChangeValueWithThrottle = async (newValue: number) => {
-    setSliderValue(newValue);
-    throttledSetValue(newValue);
-  };
-  const handleChangeValueWithoutThrottle = async (newValue: number) => {
-    setSliderValue(newValue);
-    handleChangeValue(newValue);
-  };
-
   return (
     <div className="col center slider">
       <RangeInput
@@ -67,8 +53,8 @@ const Slider = ({
         min={min}
         max={max}
         height={sliderHeight}
-        handleChange={handleChangeValueWithThrottle}
-        handleMouseUp={handleChangeValueWithoutThrottle}
+        handleChange={handleInput}
+        handleMouseUp={handleInput}
         isDisabled={!!globalError}
         incrementPrecision={0}
         displayPrecision={2}

--- a/src/renderer/graph/Axis.tsx
+++ b/src/renderer/graph/Axis.tsx
@@ -1,6 +1,11 @@
 import * as d3 from 'd3';
 import { useEffect, useRef } from 'react';
+import { useIsFirstRender } from 'renderer/utils/utils';
 import { GrayScaleEnum } from '../styles/color';
+import {
+  GRAPH_ANIMATE_DURATION,
+  INIT_ANIMATE_DURATION,
+} from './ChartController';
 
 interface IAxisProps {
   type: 'bottom' | 'left';
@@ -20,6 +25,7 @@ const Axis = ({
   disableAnimation,
 }: IAxisProps) => {
   const ref = useRef<SVGGElement>(null);
+  const isFirstRender = useIsFirstRender();
   useEffect(() => {
     const axisGenerator = type === 'left' ? d3.axisLeft : d3.axisBottom;
     const axis = tickFormat
@@ -31,7 +37,14 @@ const Axis = ({
       if (disableAnimation) {
         axisGroup.call(axis);
       } else {
-        axisGroup.transition().duration(750).ease(d3.easeLinear).call(axis);
+        const duration = isFirstRender
+          ? INIT_ANIMATE_DURATION
+          : GRAPH_ANIMATE_DURATION;
+        axisGroup
+          .transition()
+          .duration(duration)
+          .ease(d3.easeLinear)
+          .call(axis);
       }
       axisGroup.select('.domain').remove();
       axisGroup.selectAll('line').remove();
@@ -41,7 +54,7 @@ const Axis = ({
         .attr('color', GrayScaleEnum.WHITE)
         .attr('font-size', '0.75rem');
     }
-  }, [scale, tickValues, tickFormat, disableAnimation, type]);
+  }, [scale, tickValues, tickFormat, disableAnimation, type, isFirstRender]);
 
   return <g name="axis-frequency" ref={ref} transform={transform} />;
 };

--- a/src/renderer/graph/Chart.tsx
+++ b/src/renderer/graph/Chart.tsx
@@ -19,11 +19,11 @@ interface IChartProps {
 const Chart = ({ data = [], dimensions }: IChartProps) => {
   const { width, height, margins } = dimensions;
   const svgWidth = useMemo(
-    () => width - margins.left - margins.right,
+    () => Math.max(width - margins.left - margins.right, 0),
     [width, margins]
   );
   const svgHeight = useMemo(
-    () => height - margins.top - margins.bottom,
+    () => Math.max(height - margins.top - margins.bottom, 0),
     [height, margins]
   );
 

--- a/src/renderer/graph/FrequencyResponseChart.tsx
+++ b/src/renderer/graph/FrequencyResponseChart.tsx
@@ -1,5 +1,5 @@
 import { IFilter } from 'common/constants';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import Spinner from 'renderer/icons/Spinner';
 import { useAquaContext } from 'renderer/utils/AquaContext';
 import { setMainPreAmp } from 'renderer/utils/equalizerApi';
@@ -143,9 +143,31 @@ const FrequencyResponseChart = () => {
     }
   }, [autoPreAmpValue, isAutoPreAmpOn, isLoading, setPreAmp]);
 
+  const ref = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState<number>(1396);
+  const [height, setHeight] = useState<number>(380);
+
+  useLayoutEffect(() => {
+    const updateDimensions = () => {
+      const newWidth = ref.current?.clientWidth;
+      if (newWidth && newWidth > 0) {
+        setWidth(newWidth);
+      }
+      const newHeight = ref.current?.clientHeight;
+      if (newHeight && newHeight > 0) {
+        setHeight(newHeight);
+      }
+    };
+
+    // Compute dimensions on initial render
+    updateDimensions();
+    window.addEventListener('resize', updateDimensions);
+    return () => window.removeEventListener('resize', updateDimensions);
+  }, []);
+
   const dimensions: ChartDimensions = {
-    width: 1396,
-    height: 380,
+    width,
+    height,
     margins: {
       top: 30,
       right: 30,
@@ -157,7 +179,7 @@ const FrequencyResponseChart = () => {
   return (
     <>
       {isGraphViewOn && (
-        <div className="graph-wrapper">
+        <div className="graph-wrapper" ref={ref}>
           {isLoading ? (
             <div className="center full row">
               <Spinner />

--- a/src/renderer/graph/FrequencyResponseChart.tsx
+++ b/src/renderer/graph/FrequencyResponseChart.tsx
@@ -147,23 +147,27 @@ const FrequencyResponseChart = () => {
   const [width, setWidth] = useState<number>(1396);
   const [height, setHeight] = useState<number>(380);
 
-  useLayoutEffect(() => {
-    const updateDimensions = () => {
-      const newWidth = ref.current?.clientWidth;
-      if (newWidth && newWidth > 0) {
-        setWidth(newWidth);
-      }
-      const newHeight = ref.current?.clientHeight;
-      if (newHeight && newHeight > 0) {
-        setHeight(newHeight);
-      }
-    };
+  const updateDimensions = () => {
+    const newWidth = ref.current?.clientWidth;
+    if (newWidth && newWidth > 0) {
+      setWidth(newWidth);
+    }
+    const newHeight = ref.current?.clientHeight;
+    if (newHeight && newHeight > 0) {
+      setHeight(newHeight);
+    }
+  };
 
+  useLayoutEffect(() => {
     // Compute dimensions on initial render
     updateDimensions();
     window.addEventListener('resize', updateDimensions);
     return () => window.removeEventListener('resize', updateDimensions);
   }, []);
+
+  useLayoutEffect(() => {
+    updateDimensions();
+  }, [isGraphViewOn]);
 
   const dimensions: ChartDimensions = {
     width,

--- a/src/renderer/graph/GridLine.tsx
+++ b/src/renderer/graph/GridLine.tsx
@@ -1,5 +1,10 @@
 import * as d3 from 'd3';
 import { useEffect, useRef } from 'react';
+import { useIsFirstRender } from 'renderer/utils/utils';
+import {
+  GRAPH_ANIMATE_DURATION,
+  INIT_ANIMATE_DURATION,
+} from './ChartController';
 
 interface IGridLineProps {
   type: 'vertical' | 'horizontal';
@@ -21,6 +26,8 @@ const GridLine = ({
   disableAnimation,
 }: IGridLineProps) => {
   const ref = useRef<SVGGElement>(null);
+  const isFirstRender = useIsFirstRender();
+
   useEffect(() => {
     const axisGenerator = type === 'vertical' ? d3.axisBottom : d3.axisLeft;
     const axis = axisGenerator(scale).tickValues(tickValues).tickSize(-size);
@@ -30,13 +37,20 @@ const GridLine = ({
       if (disableAnimation) {
         gridGroup.call(axis);
       } else {
-        gridGroup.transition().duration(750).ease(d3.easeLinear).call(axis);
+        const duration = isFirstRender
+          ? INIT_ANIMATE_DURATION
+          : GRAPH_ANIMATE_DURATION;
+        gridGroup
+          .transition()
+          .duration(duration)
+          .ease(d3.easeLinear)
+          .call(axis);
       }
       gridGroup.select('.domain').remove();
       gridGroup.selectAll('text').remove();
       gridGroup.selectAll('line').attr('stroke', color);
     }
-  }, [scale, tickValues, size, disableAnimation, type, color]);
+  }, [scale, tickValues, size, disableAnimation, type, color, isFirstRender]);
 
   return <g ref={ref} transform={transform} />;
 };

--- a/src/renderer/styles/App.scss
+++ b/src/renderer/styles/App.scss
@@ -33,11 +33,12 @@ body {
     grid-template-rows: $equalizer-height 1fr;
 
     &.minimized {
-      grid-template-areas: 'side-bar main-content presets-bar';
       // Forcibly allow equalizer content to grow when graph view is off
       grid-template-rows: 1fr;
+      row-gap: 0px;
     }
-    gap: $spacing-s;
+
+    gap: $spacing-m $spacing-s;
   }
 }
 

--- a/src/renderer/styles/App.scss
+++ b/src/renderer/styles/App.scss
@@ -27,8 +27,16 @@ body {
     grid-template-areas:
       'side-bar main-content presets-bar'
       'graph-wrapper graph-wrapper graph-wrapper';
-    grid-template-columns: minmax($sidebar-width, max-content) 1fr $preset-bar-width;
+    grid-template-columns: $sidebar-width 1fr $preset-bar-width;
+
+    // Keep fixed height for equalizer when graph view is on
     grid-template-rows: $equalizer-height 1fr;
+
+    &.minimized {
+      grid-template-areas: 'side-bar main-content presets-bar';
+      // Forcibly allow equalizer content to grow when graph view is off
+      grid-template-rows: 1fr;
+    }
     gap: $spacing-s;
   }
 }

--- a/src/renderer/styles/App.scss
+++ b/src/renderer/styles/App.scss
@@ -54,6 +54,9 @@ body {
   grid-area: graph-wrapper;
   border-radius: $spacing-m;
   border: $spacing-xxs solid $secondary-default;
+
+  // Prevent graph from overflowing out of the wrapper's available space
+  overflow: hidden;
 }
 
 .row {

--- a/src/renderer/styles/MainContent.scss
+++ b/src/renderer/styles/MainContent.scss
@@ -18,24 +18,20 @@
   border: $spacing-xxs solid $secondary-default;
 
   .band-label {
-    height: $band-height;
-    justify-content: flex-start;
-    gap: $spacing-s;
+    height: 100%;
+    display: grid;
 
-    div {
-      justify-content: space-around;
-      height: 100%;
-    }
-
-    .row-label {
-      margin: $spacing-s 0;
-    }
-
-    &::before,
-    &::after {
-      // Insert space above and below band so scrollbar has padding
-      content: ' ';
-    }
+    grid-template-rows:
+      0px // top padding
+      30px // filter type
+      36px // frequency
+      24px // top arrow
+      min-content 1fr min-content 1fr min-content
+      24px // bottom arrow
+      36px // gain
+      36px // quality
+      0px; // bottom padding
+    gap: 8px;
   }
 
   .bands {

--- a/src/renderer/styles/MainContent.scss
+++ b/src/renderer/styles/MainContent.scss
@@ -8,6 +8,7 @@
   grid-area: main-content;
   display: grid;
   grid-template-columns: 128px 1fr;
+  grid-template-rows: 1fr;
   gap: $spacing-s;
 
   // Add additional space to the right to balance the spacing better
@@ -37,9 +38,7 @@
   .bands {
     position: relative;
     justify-content: flex-start;
-    padding: $spacing-xs $spacing-xxs; // add some horizontal padding so the outline isn't cut off at either end
-    // Add vertical padding so that having absolute positioning of the sliders does not result in the main content
-    // div cutting off the trash can icon
+    padding: 0 $spacing-xxs; // add some horizontal padding so the outline isn't cut off at either end
     height: 100%;
     width: 100%;
     overflow-x: auto;

--- a/src/renderer/styles/_constant.scss
+++ b/src/renderer/styles/_constant.scss
@@ -2,7 +2,6 @@ $preset-bar-width: 328px;
 $sidebar-width: 155px;
 $title-bar-height: 28px;
 
-$band-height: 498px;
 $band-width: 64px;
 
 $equalizer-height: 574px;

--- a/src/renderer/styles/_constant.scss
+++ b/src/renderer/styles/_constant.scss
@@ -1,11 +1,11 @@
 $preset-bar-width: 328px;
-$sidebar-width: 150px;
+$sidebar-width: 155px;
 $title-bar-height: 28px;
 
 $band-height: 498px;
 $band-width: 64px;
 
-$equalizer-height: 580px;
+$equalizer-height: 574px;
 
 // NumberInput
 $input-height: 24px;

--- a/src/renderer/utils/AquaContext.tsx
+++ b/src/renderer/utils/AquaContext.tsx
@@ -135,7 +135,7 @@ export const AquaProvider = ({ children }: IAquaProviderProps) => {
   const [isAutoPreAmpOn, setAutoPreAmpOn] = useState<boolean>(
     DEFAULT_STATE.isAutoPreAmpOn
   );
-  const [isGraphViewOn, setGraphViewOn] = useState<boolean>(
+  const [isGraphViewOn, setIsGraphViewOn] = useState<boolean>(
     DEFAULT_STATE.isGraphViewOn
   );
   const [preAmp, setPreAmp] = useState<number>(DEFAULT_STATE.preAmp);
@@ -145,6 +145,12 @@ export const AquaProvider = ({ children }: IAquaProviderProps) => {
   );
 
   const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  const setGraphViewOn = (newValue: boolean) => {
+    setIsGraphViewOn(newValue);
+    const root = document.getElementById('root');
+    root?.setAttribute('class', newValue ? '' : 'minimized');
+  };
 
   const performHealthCheck = useCallback(async () => {
     setIsLoading(true);

--- a/src/renderer/widgets/RangeInput.tsx
+++ b/src/renderer/widgets/RangeInput.tsx
@@ -11,7 +11,7 @@ interface IRangeInputProps {
   isDisabled: boolean;
   incrementPrecision?: number;
   displayPrecision?: number;
-  width: number;
+  height: string;
   handleChange: (newValue: number) => Promise<void>;
   handleMouseUp: (newValue: number) => Promise<void>;
 }
@@ -24,7 +24,7 @@ const RangeInput = ({
   isDisabled,
   incrementPrecision = 0,
   displayPrecision = 1,
-  width,
+  height,
   handleChange,
   handleMouseUp,
 }: IRangeInputProps) => {
@@ -101,8 +101,8 @@ const RangeInput = ({
             '--min': min,
             '--max': max,
             '--val': rangeValue,
-            width: `${width}px`,
-            margin: `${width / 2}px 0px`,
+            width: `${height}`,
+            margin: `calc(${height} / 2) 0px`,
           } as CSSProperties
         }
       />


### PR DESCRIPTION
# Summary
Allow user to resize the app's window by following the following heuristic:

Horizontal resizing:
- The container for the frequency bands will grow
- The graph will grow to fill the space

Vertical resizing:
- When the graph is hidden, the frequency bands will increase in height to fill the space
- When the graph is visible, the parametric section will have a fixed height and the graph will fill the space

Overall:
- The user can not shrink the app any smaller than the default size
- Toggling the graph only adjusts the height of the app - the width remains the same
- Turning the graph on will take the maximum of either the previous height or the default one
- Turning the graph off will take the default height

## Changes
- Update resize logic in `main.ts`
- Use CSS to adjust slider height
   - Change `RangeInput` to take in a string for the height
   - Determine appropriate CSS values so that the slider's height is correct given whether the graph is visible or not
- Adjust axis and gridline animation so that it matches the rest of the graph
   - slower initial animation, quicker animation when resizing
- Use `resize` event to compute the expected dimensions of the graph
   - leverage `useThrottleAndExecuteLatest` to reduce number of calls
   - Can't rely on CSS because the exact dimensions need to be passed to the d3 library
- Add `minimized` class to root to forcibly alter how the parametric components resize (depending on graph view visibility)

## Refactor
- Implement more robust CSS resizing for the frequency band labels
- Add more `useCallbacks` for any throttled functions to reduce the number of re-renders needed

## Screenshot
<img width="1297" alt="image" src="https://user-images.githubusercontent.com/30204513/218282621-d86b080e-96c9-460e-b7d3-f58123af9065.png">
<img width="1299" alt="image" src="https://user-images.githubusercontent.com/30204513/218282634-33320917-e2d8-4be5-abea-d49948eb293c.png">

