### PR TITLE
JAT-102 Setup fallback for non-case-sensitive file systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "hot",
     "reload"
   ],
-  "homepage": "https://github.com/hemit-s/AQUA",
+  "homepage": "https://github.com/h39s/AQUA",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hemit-s/AQUA.git"
+    "url": "git+https://github.com/h39s/AQUA.git"
   },
-  "license": "MIT",
+  "license": "GPLv3",
   "author": {
     "name": "JATY"
   },
@@ -258,7 +258,7 @@
     ],
     "publish": {
       "provider": "github",
-      "owner": "hemit-s",
+      "owner": "h39s",
       "repo": "AQUA"
     }
   },

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "aqua",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aqua",
-      "version": "1.0.1",
+      "version": "1.1.1",
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "GPLv3",
       "dependencies": {
         "win32-api": "^9.6.0"
       }

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,8 +1,8 @@
 {
   "name": "aqua",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An audio equalizer app",
-  "license": "MIT",
+  "license": "GPLv3",
   "author": {
     "name": "JATY"
   },

--- a/src/__tests__/unit_tests/PresetsBar.test.tsx
+++ b/src/__tests__/unit_tests/PresetsBar.test.tsx
@@ -252,25 +252,31 @@ describe('PresetListItem', () => {
       );
     });
 
+    // Assume we click the edit icon of the first preset which is Apple
     const editIcon = screen.getAllByLabelText(editIconLabel)[0];
     await user.click(editIcon);
     const editInput = screen.getByLabelText(editModeLabel);
     expect(editInput).toBeInTheDocument();
 
+    // Restricted preset name
     await clearAndType(user, editInput, 'COM1');
     await user.keyboard('{Enter}');
     expect(screen.getByText(PresetErrorEnum.RESTRICTED)).toBeInTheDocument();
 
-    // Assume we click the edit icon of the first preset which is Apple
+    // Exact duplicate exists
     await clearAndType(user, editInput, 'Banana');
     await user.keyboard('{Enter}');
     expect(screen.getByText(PresetErrorEnum.DUPLICATE)).toBeInTheDocument();
 
+    // Allow name that differs by case only
     await clearAndType(user, editInput, 'bAnAnA');
     await user.keyboard('{Enter}');
     expect(screen.getByText('bAnAnA')).toBeInTheDocument();
 
-    await clearAndType(user, editInput, 'aPpLe');
+    // Refetch editIcon and editInput because the elemnts were rerendered
+    await user.click(screen.getAllByLabelText(editIconLabel)[0]);
+    // Allow rename to the same name that differs by case only
+    await clearAndType(user, screen.getByLabelText(editModeLabel), 'aPpLe');
     await user.keyboard('{Enter}');
     expect(screen.getByText('aPpLe')).toBeInTheDocument();
   });
@@ -293,24 +299,28 @@ describe('PresetListItem', () => {
       );
     });
 
+    // Assume we click the edit icon of the first preset which is Apple
     const editIcon = screen.getAllByLabelText(editIconLabel)[0];
     await user.click(editIcon);
     const editInput = screen.getByLabelText(editModeLabel);
     expect(editInput).toBeInTheDocument();
 
+    // Restricted preset name
     await clearAndType(user, editInput, 'COM1');
     await user.keyboard('{Enter}');
     expect(screen.getByText(PresetErrorEnum.RESTRICTED)).toBeInTheDocument();
 
-    // Assume we click the edit icon of the first preset which is Apple
+    // Exact duplicate exists
     await clearAndType(user, editInput, 'Banana');
     await user.keyboard('{Enter}');
     expect(screen.getByText(PresetErrorEnum.DUPLICATE)).toBeInTheDocument();
 
+    // Duplicate that differs only by case exists
     await clearAndType(user, editInput, 'bAnAnA');
     await user.keyboard('{Enter}');
     expect(screen.getByText(PresetErrorEnum.DUPLICATE)).toBeInTheDocument();
 
+    // Allow rename to the same name that differs by case only
     await clearAndType(user, editInput, 'aPpLe');
     await user.keyboard('{Enter}');
     expect(screen.getByText('aPpLe')).toBeInTheDocument();

--- a/src/__tests__/unit_tests/PresetsBar.test.tsx
+++ b/src/__tests__/unit_tests/PresetsBar.test.tsx
@@ -270,9 +270,9 @@ describe('PresetListItem', () => {
     await user.keyboard('{Enter}');
     expect(screen.getByText('bAnAnA')).toBeInTheDocument();
 
-    // await clearAndType(user, editInput, 'aPpLe');
-    // await user.keyboard('{Enter}');
-    // expect(screen.getByText('aPpLe')).toBeInTheDocument();
+    await clearAndType(user, editInput, 'aPpLe');
+    await user.keyboard('{Enter}');
+    expect(screen.getByText('aPpLe')).toBeInTheDocument();
   });
 
   it('should disallow invalid renamed presets for case insensitive systems', async () => {

--- a/src/__tests__/unit_tests/PresetsBar.test.tsx
+++ b/src/__tests__/unit_tests/PresetsBar.test.tsx
@@ -1,0 +1,327 @@
+/*
+<AQUA: System-wide parametric audio equalizer interface>
+Copyright (C) <2023>  <AQUA Dev Team>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import '@testing-library/jest-dom';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PresetsBar, { PresetErrorEnum } from 'renderer/PresetsBar';
+import { AquaProviderWrapper } from 'renderer/utils/AquaContext';
+import defaultAquaContext from '__tests__/utils/mockAquaProvider';
+import { clearAndType, setup } from '__tests__/utils/userEventUtils';
+
+describe('PresetListItem', () => {
+  const samplePresetNames = ['Apple', 'Banana', 'Oranges'];
+  const presetNameInputLabel = 'Preset Name';
+  const loadPresetButtonLabel = 'Load selected preset';
+  const savePresetButtonLabel = 'Save settings to preset';
+  const editIconLabel = 'Edit Icon';
+  const editModeLabel = 'Edit Preset Name';
+  const caseSensitiveContext = {
+    ...defaultAquaContext,
+    isCaseSensitiveFs: true,
+  };
+
+  const fetchPresets = jest.fn();
+  const loadPreset = jest.fn();
+  const savePreset = jest.fn();
+  const renamePreset = jest.fn();
+  const deletePreset = jest.fn();
+
+  beforeEach(() => {
+    fetchPresets.mockClear();
+    loadPreset.mockClear();
+    savePreset.mockClear();
+    renamePreset.mockClear();
+    deletePreset.mockClear();
+  });
+
+  it('should be empty', async () => {
+    setup(
+      <AquaProviderWrapper value={defaultAquaContext}>
+        <PresetsBar
+          fetchPresets={fetchPresets}
+          loadPreset={loadPreset}
+          savePreset={savePreset}
+          renamePreset={renamePreset}
+          deletePreset={deletePreset}
+        />
+      </AquaProviderWrapper>
+    );
+
+    expect(screen.getByText('No presets found.')).toBeInTheDocument();
+    expect(screen.queryByText(samplePresetNames[0])).not.toBeInTheDocument();
+    expect(fetchPresets).toHaveBeenCalledTimes(1);
+  });
+
+  it('should list the presets', async () => {
+    fetchPresets.mockReturnValue(samplePresetNames);
+    await act(async () => {
+      setup(
+        <AquaProviderWrapper value={defaultAquaContext}>
+          <PresetsBar
+            fetchPresets={fetchPresets}
+            loadPreset={loadPreset}
+            savePreset={savePreset}
+            renamePreset={renamePreset}
+            deletePreset={deletePreset}
+          />
+        </AquaProviderWrapper>
+      );
+    });
+
+    expect(screen.getByText(samplePresetNames[0])).toBeInTheDocument();
+    expect(screen.getByText(samplePresetNames[1])).toBeInTheDocument();
+    expect(screen.getByText(samplePresetNames[2])).toBeInTheDocument();
+    expect(fetchPresets).toHaveBeenCalledTimes(1);
+  });
+
+  it('should support loading a preset', async () => {
+    fetchPresets.mockReturnValue(samplePresetNames);
+    const { user } = setup(
+      <AquaProviderWrapper value={defaultAquaContext}>
+        <PresetsBar
+          fetchPresets={fetchPresets}
+          loadPreset={loadPreset}
+          savePreset={savePreset}
+          renamePreset={renamePreset}
+          deletePreset={deletePreset}
+        />
+      </AquaProviderWrapper>
+    );
+
+    const presetNameInput = screen.getByLabelText(presetNameInputLabel);
+    const loadButton = screen.getByLabelText(loadPresetButtonLabel);
+    expect(loadButton).toHaveAttribute('aria-disabled', 'true');
+    await clearAndType(user, presetNameInput, samplePresetNames[0]);
+    expect(loadButton).toHaveAttribute('aria-disabled', 'false');
+    await user.click(loadButton);
+    expect(loadPreset).toHaveBeenCalledTimes(1);
+  });
+
+  it('should support saving a new preset', async () => {
+    fetchPresets.mockReturnValue(samplePresetNames);
+    const { user } = setup(
+      <AquaProviderWrapper value={defaultAquaContext}>
+        <PresetsBar
+          fetchPresets={fetchPresets}
+          loadPreset={loadPreset}
+          savePreset={savePreset}
+          renamePreset={renamePreset}
+          deletePreset={deletePreset}
+        />
+      </AquaProviderWrapper>
+    );
+
+    const presetNameInput = screen.getByLabelText(presetNameInputLabel);
+    const saveButton = screen.getByLabelText(savePresetButtonLabel);
+    expect(saveButton).toHaveAttribute('aria-disabled', 'true');
+    await clearAndType(user, presetNameInput, 'Pineapple');
+    expect(saveButton).toHaveAttribute('aria-disabled', 'false');
+    await user.click(saveButton);
+    expect(savePreset).toHaveBeenCalledTimes(1);
+  });
+
+  it('should support saving an existing preset', async () => {
+    fetchPresets.mockReturnValue(samplePresetNames);
+    const { user } = setup(
+      <AquaProviderWrapper value={defaultAquaContext}>
+        <PresetsBar
+          fetchPresets={fetchPresets}
+          loadPreset={loadPreset}
+          savePreset={savePreset}
+          renamePreset={renamePreset}
+          deletePreset={deletePreset}
+        />
+      </AquaProviderWrapper>
+    );
+
+    const presetNameInput = screen.getByLabelText(presetNameInputLabel);
+    const saveButton = screen.getByLabelText(savePresetButtonLabel);
+    expect(saveButton).toHaveAttribute('aria-disabled', 'true');
+    await clearAndType(user, presetNameInput, samplePresetNames[0]);
+    expect(saveButton).toHaveAttribute('aria-disabled', 'false');
+    await user.click(saveButton);
+    expect(savePreset).toHaveBeenCalledTimes(1);
+  });
+
+  it('should disallow invalid new preset names for case sensitive systems', async () => {
+    fetchPresets.mockReturnValue(samplePresetNames);
+    const { user } = setup(
+      <AquaProviderWrapper value={caseSensitiveContext}>
+        <PresetsBar
+          fetchPresets={fetchPresets}
+          loadPreset={loadPreset}
+          savePreset={savePreset}
+          renamePreset={renamePreset}
+          deletePreset={deletePreset}
+        />
+      </AquaProviderWrapper>
+    );
+
+    const presetNameInput = screen.getByLabelText(presetNameInputLabel);
+    const saveButton = screen.getByLabelText(savePresetButtonLabel);
+    expect(saveButton).toHaveAttribute('aria-disabled', 'true');
+
+    // Submitting with no name should not save
+    await user.type(presetNameInput, '{Enter}');
+    expect(savePreset).toHaveBeenCalledTimes(0);
+
+    // Restricted preset name
+    await clearAndType(user, presetNameInput, 'CON');
+    expect(saveButton).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByText(PresetErrorEnum.RESTRICTED)).toBeInTheDocument();
+
+    // Submitting with an error present should not save
+    await user.type(presetNameInput, '{Enter}');
+    expect(savePreset).toHaveBeenCalledTimes(0);
+  });
+
+  it('should disallow invalid new preset names for case insensitive systems', async () => {
+    fetchPresets.mockReturnValue(samplePresetNames);
+    const { user } = setup(
+      <AquaProviderWrapper value={defaultAquaContext}>
+        <PresetsBar
+          fetchPresets={fetchPresets}
+          loadPreset={loadPreset}
+          savePreset={savePreset}
+          renamePreset={renamePreset}
+          deletePreset={deletePreset}
+        />
+      </AquaProviderWrapper>
+    );
+
+    const presetNameInput = screen.getByLabelText(presetNameInputLabel);
+    const saveButton = screen.getByLabelText(savePresetButtonLabel);
+    expect(saveButton).toHaveAttribute('aria-disabled', 'true');
+
+    // Restricted preset name
+    await clearAndType(user, presetNameInput, 'CON');
+    expect(saveButton).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByText(PresetErrorEnum.RESTRICTED)).toBeInTheDocument();
+
+    // Duplicate preset name that isn't an exact match
+    await clearAndType(
+      user,
+      presetNameInput,
+      samplePresetNames[0].toLocaleLowerCase()
+    );
+    expect(saveButton).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByText(PresetErrorEnum.DUPLICATE)).toBeInTheDocument();
+  });
+
+  it('should disallow invalid renamed presets for case sensitive systems', async () => {
+    fetchPresets.mockReturnValue(samplePresetNames);
+    const user = userEvent.setup();
+
+    await act(async () => {
+      setup(
+        <AquaProviderWrapper value={caseSensitiveContext}>
+          <PresetsBar
+            fetchPresets={fetchPresets}
+            loadPreset={loadPreset}
+            savePreset={savePreset}
+            renamePreset={renamePreset}
+            deletePreset={deletePreset}
+          />
+        </AquaProviderWrapper>
+      );
+    });
+
+    const editIcon = screen.getAllByLabelText(editIconLabel)[0];
+    await user.click(editIcon);
+    const editInput = screen.getByLabelText(editModeLabel);
+    expect(editInput).toBeInTheDocument();
+
+    await clearAndType(user, editInput, 'COM1');
+    await user.keyboard('{Enter}');
+    expect(screen.getByText(PresetErrorEnum.RESTRICTED)).toBeInTheDocument();
+
+    // Assume we click the edit icon of the first preset which is Apple
+    await clearAndType(user, editInput, 'Banana');
+    await user.keyboard('{Enter}');
+    expect(screen.getByText(PresetErrorEnum.DUPLICATE)).toBeInTheDocument();
+
+    await clearAndType(user, editInput, 'bAnAnA');
+    await user.keyboard('{Enter}');
+    expect(screen.getByText('bAnAnA')).toBeInTheDocument();
+  });
+
+  it('should disallow invalid renamed presets for case insensitive systems', async () => {
+    fetchPresets.mockReturnValue(samplePresetNames);
+    const user = userEvent.setup();
+
+    await act(async () => {
+      setup(
+        <AquaProviderWrapper value={defaultAquaContext}>
+          <PresetsBar
+            fetchPresets={fetchPresets}
+            loadPreset={loadPreset}
+            savePreset={savePreset}
+            renamePreset={renamePreset}
+            deletePreset={deletePreset}
+          />
+        </AquaProviderWrapper>
+      );
+    });
+
+    const editIcon = screen.getAllByLabelText(editIconLabel)[0];
+    await user.click(editIcon);
+    const editInput = screen.getByLabelText(editModeLabel);
+    expect(editInput).toBeInTheDocument();
+
+    await clearAndType(user, editInput, 'COM1');
+    await user.keyboard('{Enter}');
+    expect(screen.getByText(PresetErrorEnum.RESTRICTED)).toBeInTheDocument();
+
+    // Assume we click the edit icon of the first preset which is Apple
+    await clearAndType(user, editInput, 'Banana');
+    await user.keyboard('{Enter}');
+    expect(screen.getByText(PresetErrorEnum.DUPLICATE)).toBeInTheDocument();
+
+    await clearAndType(user, editInput, 'bAnAnA');
+    await user.keyboard('{Enter}');
+    expect(screen.getByText(PresetErrorEnum.DUPLICATE)).toBeInTheDocument();
+
+    await clearAndType(user, editInput, 'aPpLe');
+    await user.keyboard('{Enter}');
+    expect(screen.getByText('aPpLe')).toBeInTheDocument();
+  });
+
+  it('should disallow loading non-existant presets', async () => {
+    fetchPresets.mockReturnValue(samplePresetNames);
+    const { user } = setup(
+      <AquaProviderWrapper value={defaultAquaContext}>
+        <PresetsBar
+          fetchPresets={fetchPresets}
+          loadPreset={loadPreset}
+          savePreset={savePreset}
+          renamePreset={renamePreset}
+          deletePreset={deletePreset}
+        />
+      </AquaProviderWrapper>
+    );
+    // type in non existent presetname
+    const textbox = screen.getByLabelText(presetNameInputLabel);
+    expect(textbox).toBeInTheDocument();
+    await user.type(textbox, 'john cena');
+    expect(screen.getByLabelText(loadPresetButtonLabel)).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+});

--- a/src/__tests__/unit_tests/PresetsBar.test.tsx
+++ b/src/__tests__/unit_tests/PresetsBar.test.tsx
@@ -189,6 +189,16 @@ describe('PresetListItem', () => {
     // Submitting with an error present should not save
     await user.type(presetNameInput, '{Enter}');
     expect(savePreset).toHaveBeenCalledTimes(0);
+
+    // Allow preset name that isn't an exact match
+    await clearAndType(
+      user,
+      presetNameInput,
+      samplePresetNames[0].toLocaleLowerCase()
+    );
+    expect(saveButton).toHaveAttribute('aria-disabled', 'false');
+    await user.type(presetNameInput, '{Enter}');
+    expect(savePreset).toHaveBeenCalledTimes(1);
   });
 
   it('should disallow invalid new preset names for case insensitive systems', async () => {
@@ -259,6 +269,10 @@ describe('PresetListItem', () => {
     await clearAndType(user, editInput, 'bAnAnA');
     await user.keyboard('{Enter}');
     expect(screen.getByText('bAnAnA')).toBeInTheDocument();
+
+    // await clearAndType(user, editInput, 'aPpLe');
+    // await user.keyboard('{Enter}');
+    // expect(screen.getByText('aPpLe')).toBeInTheDocument();
   });
 
   it('should disallow invalid renamed presets for case insensitive systems', async () => {

--- a/src/__tests__/unit_tests/TextInput.test.tsx
+++ b/src/__tests__/unit_tests/TextInput.test.tsx
@@ -132,11 +132,11 @@ describe('TextInput', () => {
 
   it('should be disabled', async () => {
     const testValue = 'Standard';
-    setup(
+    const { user } = setup(
       <TextInput
         value={testValue}
         ariaLabel={name}
-        handleChange={handleChange}
+        handleSubmit={handleSubmit}
         handleEscape={handleEscape}
         isDisabled
         errorMessage=""
@@ -147,5 +147,8 @@ describe('TextInput', () => {
       'aria-disabled',
       'true'
     );
+    const editInput = screen.getByLabelText(name);
+    await user.type(editInput, '{Enter}');
+    expect(handleSubmit).toBeCalledTimes(0);
   });
 });

--- a/src/__tests__/unit_tests/common/utils.test.ts
+++ b/src/__tests__/unit_tests/common/utils.test.ts
@@ -27,7 +27,13 @@ import {
   isRestrictedPresetName,
   roundToPrecision,
 } from 'common/utils';
-import { sortHelper } from 'renderer/utils/utils';
+import {
+  comparePaddedStrings,
+  decodePresetName,
+  encodePresetName,
+  padPresetName,
+  sortHelper,
+} from 'renderer/utils/utils';
 
 describe('utils', () => {
   describe('roundToPrecision', () => {
@@ -92,6 +98,42 @@ describe('utils', () => {
       Object.entries(copy).forEach(([id, filter]) => {
         expect(filter.id).toBe(`${id}`);
       });
+    });
+  });
+
+  describe('Preset Name encoding/decoding', () => {
+    const decoded = '7Hz Salnotes Dioko( sample 2)';
+    const encoded = '7^hz ^salnotes ^dioko( sample 2)';
+    const invalidEncoded = '^7^^hz ^salnotes ^dioko( sample 2)';
+    it('should encode preset name by removing upper letters and prepending with the carat', () => {
+      expect(encodePresetName(decoded)).toBe(encoded);
+    });
+
+    it('should decode preset name parsing carat', () => {
+      expect(decodePresetName(encoded)).toBe(decoded);
+    });
+
+    it('operations should be the inverse of each other', () => {
+      expect(decodePresetName(encodePresetName(decoded))).toBe(decoded);
+    });
+
+    it('should clean out any invalid characters after decoding', () => {
+      expect(decodePresetName(invalidEncoded)).toBe(decoded);
+    });
+
+    it('should pad a string correctly', () => {
+      expect(padPresetName('ab', ['aB', 'Ab\xa0\xa0'])).toBe('ab\xa0');
+      expect(padPresetName('ab', ['aB', 'Ab\xa0'])).toBe('ab\xa0\xa0');
+      expect(padPresetName('ab', ['aB\xa0', 'Ab\xa0'])).toBe('ab');
+      expect(padPresetName('ab', ['aB\xa0\xa0', 'Ab\xa0'])).toBe('ab');
+      expect(padPresetName('ab', [])).toBe('ab');
+    });
+
+    it('should compare padded strings with non-padded strings', () => {
+      expect(comparePaddedStrings('ab', 'ab')).toBe(true);
+      expect(comparePaddedStrings('ab\xa0', 'ab')).toBe(true);
+      expect(comparePaddedStrings('ab', 'aB')).toBe(false);
+      expect(comparePaddedStrings('ab\xa0', 'aB')).toBe(false);
     });
   });
 });

--- a/src/__tests__/unit_tests/common/utils.test.ts
+++ b/src/__tests__/unit_tests/common/utils.test.ts
@@ -27,13 +27,7 @@ import {
   isRestrictedPresetName,
   roundToPrecision,
 } from 'common/utils';
-import {
-  comparePaddedStrings,
-  decodePresetName,
-  encodePresetName,
-  padPresetName,
-  sortHelper,
-} from 'renderer/utils/utils';
+import { sortHelper } from 'renderer/utils/utils';
 
 describe('utils', () => {
   describe('roundToPrecision', () => {
@@ -98,42 +92,6 @@ describe('utils', () => {
       Object.entries(copy).forEach(([id, filter]) => {
         expect(filter.id).toBe(`${id}`);
       });
-    });
-  });
-
-  describe('Preset Name encoding/decoding', () => {
-    const decoded = '7Hz Salnotes Dioko( sample 2)';
-    const encoded = '7^hz ^salnotes ^dioko( sample 2)';
-    const invalidEncoded = '^7^^hz ^salnotes ^dioko( sample 2)';
-    it('should encode preset name by removing upper letters and prepending with the carat', () => {
-      expect(encodePresetName(decoded)).toBe(encoded);
-    });
-
-    it('should decode preset name parsing carat', () => {
-      expect(decodePresetName(encoded)).toBe(decoded);
-    });
-
-    it('operations should be the inverse of each other', () => {
-      expect(decodePresetName(encodePresetName(decoded))).toBe(decoded);
-    });
-
-    it('should clean out any invalid characters after decoding', () => {
-      expect(decodePresetName(invalidEncoded)).toBe(decoded);
-    });
-
-    it('should pad a string correctly', () => {
-      expect(padPresetName('ab', ['aB', 'Ab\xa0\xa0'])).toBe('ab\xa0');
-      expect(padPresetName('ab', ['aB', 'Ab\xa0'])).toBe('ab\xa0\xa0');
-      expect(padPresetName('ab', ['aB\xa0', 'Ab\xa0'])).toBe('ab');
-      expect(padPresetName('ab', ['aB\xa0\xa0', 'Ab\xa0'])).toBe('ab');
-      expect(padPresetName('ab', [])).toBe('ab');
-    });
-
-    it('should compare padded strings with non-padded strings', () => {
-      expect(comparePaddedStrings('ab', 'ab')).toBe(true);
-      expect(comparePaddedStrings('ab\xa0', 'ab')).toBe(true);
-      expect(comparePaddedStrings('ab', 'aB')).toBe(false);
-      expect(comparePaddedStrings('ab\xa0', 'aB')).toBe(false);
     });
   });
 });

--- a/src/__tests__/utils/mockAquaProvider.ts
+++ b/src/__tests__/utils/mockAquaProvider.ts
@@ -29,6 +29,7 @@ const defaultAquaContext: IAquaContext = {
   isEnabled: DEFAULT_STATE.isEnabled,
   isAutoPreAmpOn: DEFAULT_STATE.isAutoPreAmpOn,
   isGraphViewOn: DEFAULT_STATE.isGraphViewOn,
+  isCaseSensitiveFs: DEFAULT_STATE.isCaseSensitiveFs,
   preAmp: DEFAULT_STATE.preAmp,
   filters: DEFAULT_STATE.filters,
   performHealthCheck: () => {},

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -85,6 +85,7 @@ export interface IState {
   isEnabled: boolean;
   isAutoPreAmpOn: boolean;
   isGraphViewOn: boolean;
+  isCaseSensitiveFs: boolean;
   preAmp: number;
   filters: IFiltersMap;
 }
@@ -133,6 +134,7 @@ export const getDefaultState = (): IState => {
     isEnabled: true,
     isAutoPreAmpOn: true,
     isGraphViewOn: true, // true as default so that spinner can be seen on initial load
+    isCaseSensitiveFs: false, // false as default so we assume windows fs behavior
     preAmp: 0,
     filters: getDefaultFilters(),
   };

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -134,7 +134,7 @@ export const getDefaultState = (): IState => {
     isEnabled: true,
     isAutoPreAmpOn: true,
     isGraphViewOn: true, // true as default so that spinner can be seen on initial load
-    isCaseSensitiveFs: false, // false as default so we assume windows fs behavior
+    isCaseSensitiveFs: false, // false as default so we assume windows case insensitive behavior (foo = FoO)
     preAmp: 0,
     filters: getDefaultFilters(),
   };

--- a/src/main/flush.ts
+++ b/src/main/flush.ts
@@ -85,7 +85,8 @@ export const fetchSettings = (settingsDir: string) => {
     if (!validateState(input)) {
       throw new Error('Invalid state file loaded. Using default state.');
     }
-    return input as IState;
+    // Manually set case sensitivity as false until it is confirmed in app that it can be enabled
+    return { ...input, isCaseSensitiveFs: false } as IState;
   } catch (ex) {
     console.log(ex);
     // if unable to fetch the state, use a default one

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -133,9 +133,9 @@ try {
       console.log(stdout);
     }
   );
+  state.isCaseSensitiveFs = true;
 } catch (e) {
   console.error(e);
-  throw e;
 }
 
 const retryHelper = async (attempts: number, f: () => unknown) => {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -261,7 +261,7 @@ export default class MenuBuilder {
           {
             label: 'Documentation',
             click() {
-              shell.openExternal('https://github.com/hemit-s/AQUA');
+              shell.openExternal('https://github.com/h39s/AQUA');
             },
           },
         ],

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -25,6 +25,13 @@ import SideBar from './SideBar';
 import FrequencyResponseChart from './graph/FrequencyResponseChart';
 import PresetsBar from './PresetsBar';
 import AutoEQ from './AutoEQ';
+import {
+  deletePreset,
+  getPresetListFromFiles,
+  loadPreset,
+  renamePreset,
+  savePreset,
+} from './utils/equalizerApi';
 
 const AppContent = () => {
   const { isLoading, globalError, performHealthCheck } = useAquaContext();
@@ -36,7 +43,13 @@ const AppContent = () => {
         <AutoEQ />
         <MainContent />
       </div>
-      <PresetsBar />
+      <PresetsBar
+        fetchPresets={getPresetListFromFiles}
+        loadPreset={loadPreset}
+        savePreset={savePreset}
+        renamePreset={renamePreset}
+        deletePreset={deletePreset}
+      />
       <FrequencyResponseChart />
       {globalError && (
         <PrereqMissingModal

--- a/src/renderer/PresetsBar.tsx
+++ b/src/renderer/PresetsBar.tsx
@@ -174,31 +174,31 @@ const PresetsBar = ({
   }, []);
 
   const validatePresetNew = useCallback(
-    (newValue: string) => {
+    (newName: string) => {
       /**
        * For a not case sensitive file system (apple is equal to ApPlE), we want to prevent users from creating a new preset
-       * that has the same characters that differs only in case. However, we want to allow users to specify an exact duplicate
+       * that has the same characters that differ only in case. However, we want to allow users to specify an exact duplicate
        * (where the characters and the case both match) so they can overwrite their existing presets.
        */
       if (
         !isCaseSensitiveFs &&
         presetNames.some(
-          (value) =>
-            newValue.toLocaleLowerCase() === value.toLocaleLowerCase() &&
-            value !== newValue
+          (existingName) =>
+            newName.toLocaleLowerCase() === existingName.toLocaleLowerCase() &&
+            existingName !== newName
         )
       ) {
         return PresetErrorEnum.DUPLICATE;
       }
-      return validatePresetName(newValue);
+      return validatePresetName(newName);
     },
     [isCaseSensitiveFs, presetNames, validatePresetName]
   );
 
   // Validating a preset rename
   const validatePresetRename = useCallback(
-    (oldValue: string) => (newValue: string) => {
-      if (!newValue) {
+    (oldName: string) => (newName: string) => {
+      if (!newName) {
         return PresetErrorEnum.EMPTY;
       }
 
@@ -208,18 +208,21 @@ const PresetsBar = ({
        *   - rename "banana" to "Apple" when another "apple" preset exists -> Case Insensitive: DUPLICATE, Case Sensitive: allowed
        */
       if (
-        presetNames.some(
-          (value) =>
-            value !== oldValue &&
-            (isCaseSensitiveFs
-              ? value === newValue
-              : value.toLocaleLowerCase() === newValue.toLocaleLowerCase())
-        )
+        isCaseSensitiveFs
+          ? presetNames.some(
+              (existingName) =>
+                existingName !== oldName && existingName === newName
+            )
+          : presetNames.some(
+              (existingName) =>
+                existingName !== oldName &&
+                existingName.toLocaleLowerCase() === newName.toLocaleLowerCase()
+            )
       ) {
         return PresetErrorEnum.DUPLICATE;
       }
 
-      return validatePresetName(newValue);
+      return validatePresetName(newName);
     },
     [isCaseSensitiveFs, presetNames, validatePresetName]
   );

--- a/src/renderer/components/PresetListItem.tsx
+++ b/src/renderer/components/PresetListItem.tsx
@@ -84,7 +84,7 @@ const PresetListItem = ({
         />
       ) : (
         <>
-          {value}
+          <div className="preset-name">{value}</div>
           <div className="row icons">
             <IconButton
               icon={IconName.EDIT}

--- a/src/renderer/styles/PresetsBar.scss
+++ b/src/renderer/styles/PresetsBar.scss
@@ -54,6 +54,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     justify-content: space-between;
     align-items: center;
 
+    // Ensure icons don't get pushed out of the way
+    display: grid;
+    grid-template-columns: 1fr max-content;
+    column-gap: $spacing-s;
+
+    .preset-name {
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+    }
+
     .icons {
       display: none;
       gap: $spacing-s;

--- a/src/renderer/utils/AquaContext.tsx
+++ b/src/renderer/utils/AquaContext.tsx
@@ -157,6 +157,9 @@ export const AquaProvider = ({ children }: IAquaProviderProps) => {
   const [isGraphViewOn, setIsGraphViewOn] = useState<boolean>(
     DEFAULT_STATE.isGraphViewOn
   );
+  const [isCaseSensitiveFs, setIsCaseSensitiveFs] = useState<boolean>(
+    DEFAULT_STATE.isCaseSensitiveFs
+  );
   const [preAmp, setPreAmp] = useState<number>(DEFAULT_STATE.preAmp);
   const [filters, dispatchFilter] = useReducer<IFilterReducer>(
     filterReducer,
@@ -181,6 +184,7 @@ export const AquaProvider = ({ children }: IAquaProviderProps) => {
       setPreAmp(state.preAmp);
       dispatchFilter({ type: FilterActionEnum.INIT, filters: state.filters });
       setGlobalError(undefined);
+      setIsCaseSensitiveFs(state.isCaseSensitiveFs);
     } catch (e) {
       setGlobalError(e as ErrorDescription);
     }
@@ -199,6 +203,7 @@ export const AquaProvider = ({ children }: IAquaProviderProps) => {
         isEnabled,
         isAutoPreAmpOn,
         isGraphViewOn,
+        isCaseSensitiveFs,
         preAmp,
         filters,
         performHealthCheck,

--- a/src/renderer/utils/utils.ts
+++ b/src/renderer/utils/utils.ts
@@ -39,7 +39,53 @@ export const range = (start: number, stop: number, step: number) =>
   Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step);
 
 export const formatPresetName = (s: string) => {
-  return s.replace(/[^a-zA-Z0-9|_|\-| ]+/, '');
+  return s.replaceAll(/[^a-zA-Z0-9|_|\-()| ]+/g, '');
+};
+
+export const encodePresetName = (s: string) => {
+  return s.replaceAll(/[A-Z]/g, (x) => `^${x.toLocaleLowerCase()}`);
+};
+
+export const decodePresetName = (s: string) => {
+  return formatPresetName(
+    s.replaceAll(/\^[a-z]/g, (x) => `${x[1].toLocaleUpperCase()}`)
+  );
+};
+
+export const findMissingGap = (arr: number[]) => {
+  if (arr.length === 0) {
+    return 0;
+  }
+
+  for (let i = 0; i < arr.length; i += 1) {
+    const temp = arr[i];
+    if (temp < arr.length && temp !== i) {
+      arr[i] = arr[temp];
+      arr[temp] = temp;
+    }
+  }
+
+  for (let i = 0; i < arr.length; i += 1) {
+    if (arr[i] !== i) {
+      return i;
+    }
+  }
+
+  return arr.length;
+};
+
+export const padPresetName = (s: string, names: string[]) => {
+  const spaceCounts = names
+    .filter((n) => n.trim().toLocaleLowerCase() === s.toLocaleLowerCase())
+    .map((n) => n.length - s.length);
+
+  const numSpaces = findMissingGap(spaceCounts);
+
+  return s.padEnd(s.length + numSpaces, String.fromCharCode(160));
+};
+
+export const comparePaddedStrings = (a: string, b: string) => {
+  return a.trim() === b.trim();
 };
 
 // *** CUSTOM HOOKS ***

--- a/src/renderer/utils/utils.ts
+++ b/src/renderer/utils/utils.ts
@@ -42,52 +42,6 @@ export const formatPresetName = (s: string) => {
   return s.replaceAll(/[^a-zA-Z0-9|_|\-()| ]+/g, '');
 };
 
-export const encodePresetName = (s: string) => {
-  return s.replaceAll(/[A-Z]/g, (x) => `^${x.toLocaleLowerCase()}`);
-};
-
-export const decodePresetName = (s: string) => {
-  return formatPresetName(
-    s.replaceAll(/\^[a-z]/g, (x) => `${x[1].toLocaleUpperCase()}`)
-  );
-};
-
-export const findMissingGap = (arr: number[]) => {
-  if (arr.length === 0) {
-    return 0;
-  }
-
-  for (let i = 0; i < arr.length; i += 1) {
-    const temp = arr[i];
-    if (temp < arr.length && temp !== i) {
-      arr[i] = arr[temp];
-      arr[temp] = temp;
-    }
-  }
-
-  for (let i = 0; i < arr.length; i += 1) {
-    if (arr[i] !== i) {
-      return i;
-    }
-  }
-
-  return arr.length;
-};
-
-export const padPresetName = (s: string, names: string[]) => {
-  const spaceCounts = names
-    .filter((n) => n.trim().toLocaleLowerCase() === s.toLocaleLowerCase())
-    .map((n) => n.length - s.length);
-
-  const numSpaces = findMissingGap(spaceCounts);
-
-  return s.padEnd(s.length + numSpaces, String.fromCharCode(160));
-};
-
-export const comparePaddedStrings = (a: string, b: string) => {
-  return a.trim() === b.trim();
-};
-
 // *** CUSTOM HOOKS ***
 
 // https://overreacted.io/making-setinterval-declarative-with-react-hooks/

--- a/src/renderer/widgets/TextInput.tsx
+++ b/src/renderer/widgets/TextInput.tsx
@@ -108,12 +108,12 @@ const TextInput = forwardRef(
           handleEscape();
         }
 
-        // Submit changes when the Enter key is pressed
-        if (e.code === 'Enter') {
+        // Submit changes when the Enter key is pressed (prevent this action if the input is disabled!)
+        if (e.code === 'Enter' && !isDisabled) {
           submitValue(storedValue);
         }
       },
-      [handleEscape, submitValue, storedValue]
+      [handleEscape, isDisabled, submitValue, storedValue]
     );
 
     const onChange = useCallback(


### PR DESCRIPTION
# Summary
Add functionality to adjust preset name case sensitivity to match the file system rules.

## Changes
- Add a global flag `isCaseSensitiveFs` to `IState` with a default of `false`
- Set flag to `true` if we are able to successfully enable case sensitivity in the preset folder
- Add case insensitive validation for the following cases:
   - Creating a new preset
   - Saving to an existing preset
   - Renaming an existing preset

## Miscellaneous
- Fix bug where users could attempt to save erroneous preset names by pressing `Enter`
- Improve styling of preset list in the case where an unbreakable word overflows horizontally

## Tests
- Add tests to validate preset name validation
- Add test to ensure that text inputs can't be submitted using the `Enter` button when it is in a disabled state