### PR TITLE
JAT-114 Preset menu overflows when adding more presets

### DIFF
--- a/src/renderer/styles/App.scss
+++ b/src/renderer/styles/App.scss
@@ -45,14 +45,14 @@ body {
     grid-template-areas:
       'side-bar middle-content presets-bar'
       'graph-wrapper graph-wrapper graph-wrapper';
-    grid-template-columns: minmax($sidebar-width, max-content) 1fr $preset-bar-width;
+    grid-template-columns: $sidebar-width 1fr $preset-bar-width;
     // Keep fixed height for equalizer when graph view is on
     grid-template-rows: $equalizer-height 1fr;
     gap: $spacing-s;
 
     &.minimized {
       // Forcibly allow equalizer content to grow when graph view is off
-      grid-template-rows: 1fr;
+      grid-template-rows: minmax(0px, 1fr);
       row-gap: 0px;
     }
   }

--- a/src/renderer/styles/List.scss
+++ b/src/renderer/styles/List.scss
@@ -35,6 +35,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     margin-block-end: 0px;
 
     // Apply custom styles
+    height: 100%;
     overflow-y: auto;
 
     li {

--- a/src/renderer/styles/PresetsBar.scss
+++ b/src/renderer/styles/PresetsBar.scss
@@ -25,7 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
   // Spacing of the contents
   display: grid;
-  grid-template-rows: repeat(3, min-content) 1fr min-content;
+  grid-template-rows: repeat(3, min-content) minmax(0px, 1fr) min-content;
   padding: $spacing-m;
   gap: $spacing-s;
   justify-items: stretch;


### PR DESCRIPTION
## Changes
- Add max height to the presets list to prevent overflow with graph view enabled
- Add max height to the main content when graph view is minimized to prevent preset list from overflowing the container

## Screenshots
Full screen and toggling graph view:
![image](https://user-images.githubusercontent.com/30204513/227738847-c9db1e2d-644c-4c5f-ac72-ee5708ff3747.png)
![image](https://user-images.githubusercontent.com/30204513/227738864-68f07dd6-c83b-40d0-bcf0-21a5cedbad1c.png)

Windowed screen and toggling graph view:
![image](https://user-images.githubusercontent.com/30204513/227738895-9cc6c909-fa84-4d89-a2e6-c86dfb0345ee.png)
![image](https://user-images.githubusercontent.com/30204513/227738897-eba5dafc-caa5-48bf-b68b-14e5f367f0e1.png)


