### PR TITLE
JAT-104 Add functionality to clear/reset AQUA settings to "default"

### DIFF
--- a/src/__tests__/unit_tests/common/utils.test.ts
+++ b/src/__tests__/unit_tests/common/utils.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   cloneFilters,
   computeAvgFreq,
+  isFixedBandSizeEnumValue,
   isRestrictedPresetName,
   roundToPrecision,
 } from 'common/utils';
@@ -92,6 +93,21 @@ describe('utils', () => {
       Object.entries(copy).forEach(([id, filter]) => {
         expect(filter.id).toBe(`${id}`);
       });
+    });
+  });
+
+  describe('isFixedBandSizeEnumValue', () => {
+    it('should be true for valid fixed band size values', () => {
+      expect(isFixedBandSizeEnumValue(6)).toBeTruthy();
+      expect(isFixedBandSizeEnumValue(10)).toBeTruthy();
+      expect(isFixedBandSizeEnumValue(15)).toBeTruthy();
+      expect(isFixedBandSizeEnumValue(31)).toBeTruthy();
+    });
+
+    it('should be false for invalid fixed band size values', () => {
+      expect(isFixedBandSizeEnumValue(1)).toBeFalsy();
+      expect(isFixedBandSizeEnumValue(-1)).toBeFalsy();
+      expect(isFixedBandSizeEnumValue(16)).toBeFalsy();
     });
   });
 });

--- a/src/common/channels.ts
+++ b/src/common/channels.ts
@@ -45,6 +45,8 @@ enum ChannelEnum {
   GET_AUTO_EQ_DEVICE_LIST = 'getAutoEqDeviceList',
   GET_AUTO_EQ_RESPONSE_LIST = 'getAutoEqResponseList',
   LOAD_AUTO_EQ_PRESET = 'loadAutoEqPreset',
+  CLEAR_GAINS = 'clearGains',
+  SET_FIXED_BAND = 'setFixedBand',
 }
 
 export default ChannelEnum;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -102,9 +102,28 @@ export interface IPresetV2 {
 
 /** ----- Default Values ----- */
 
-const FIXED_FREQUENCIES = [
-  32, 64, 125, 250, 500, 1000, 2000, 4000, 8000, 16000,
-];
+export enum FixedBandSizeEnum {
+  SIX = 6,
+  TEN = 10,
+  FIFTEEN = 15,
+  THIRTY_ONE = 31,
+}
+
+export const FIXED_BAND_FREQUENCIES: Record<FixedBandSizeEnum, number[]> = {
+  [FixedBandSizeEnum.SIX]: [100, 200, 400, 800, 1600, 3200],
+  [FixedBandSizeEnum.TEN]: [
+    32, 64, 125, 250, 500, 1000, 2000, 4000, 8000, 16000,
+  ],
+  [FixedBandSizeEnum.FIFTEEN]: [
+    25, 40, 63, 100, 160, 250, 400, 630, 1000, 1600, 2500, 4000, 6300, 10000,
+    16000,
+  ],
+  [FixedBandSizeEnum.THIRTY_ONE]: [
+    20, 25, 31.5, 40, 50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
+    800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000, 10000,
+    12500, 16000, 20000,
+  ],
+};
 
 const DEFAULT_FILTER_TEMPLATE = {
   frequency: 1000,
@@ -120,9 +139,11 @@ export const getDefaultFilterWithId = (): IFilter => {
   };
 };
 
-const getDefaultFilters = (): IFiltersMap => {
+export const getDefaultFilters = (
+  size: FixedBandSizeEnum = FixedBandSizeEnum.TEN
+): IFiltersMap => {
   const filters: IFiltersMap = {};
-  FIXED_FREQUENCIES.forEach((f) => {
+  FIXED_BAND_FREQUENCIES[size].forEach((f) => {
     const filter: IFilter = { ...getDefaultFilterWithId(), frequency: f };
     filters[filter.id] = filter;
   });

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -22,6 +22,7 @@ import {
   MAX_FREQUENCY,
   MIN_FREQUENCY,
   RESERVED_FILE_NAMES_SET,
+  FixedBandSizeEnum,
 } from './constants';
 
 export const roundToPrecision = (value: number, precision: number) => {
@@ -52,3 +53,8 @@ export const cloneFilters = (filters: IFiltersMap) => {
   });
   return filtersClone;
 };
+
+export const isFixedBandSizeEnumValue = (value: number) =>
+  Object.values(FixedBandSizeEnum)
+    .filter((key) => !Number.isNaN(Number(key)))
+    .some((enumValue) => enumValue === value);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -71,7 +71,10 @@ import {
   IFiltersMap,
 } from '../common/constants';
 import { ErrorCode } from '../common/errors';
-import { isRestrictedPresetName } from '../common/utils';
+import {
+  isFixedBandSizeEnumValue,
+  isRestrictedPresetName,
+} from '../common/utils';
 import { TSuccess, TError } from '../renderer/utils/equalizerApi';
 import {
   getAutoEqDeviceList,
@@ -653,6 +656,9 @@ ipcMain.on(ChannelEnum.CLEAR_GAINS, async (event) => {
 ipcMain.on(ChannelEnum.SET_FIXED_BAND, async (event, arg) => {
   const channel = ChannelEnum.SET_FIXED_BAND;
   const size: FixedBandSizeEnum = arg[0];
+  if (!isFixedBandSizeEnumValue(size)) {
+    handleError(event, channel, ErrorCode.INVALID_PARAMETER);
+  }
 
   state.filters = getDefaultFilters(size);
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -66,6 +66,9 @@ import {
   WINDOW_HEIGHT_EXPANDED,
   WINDOW_WIDTH,
   getDefaultFilterWithId,
+  FixedBandSizeEnum,
+  getDefaultFilters,
+  IFiltersMap,
 } from '../common/constants';
 import { ErrorCode } from '../common/errors';
 import { isRestrictedPresetName } from '../common/utils';
@@ -635,6 +638,25 @@ ipcMain.on(ChannelEnum.REMOVE_FILTER, async (event, arg) => {
   // delete does not throw exception even if the filterId does not exist
   delete state.filters[filterId];
   await handleUpdate(event, channel);
+});
+
+ipcMain.on(ChannelEnum.CLEAR_GAINS, async (event) => {
+  const channel = ChannelEnum.CLEAR_GAINS;
+
+  Object.keys(state.filters).forEach((key) => {
+    state.filters[key].gain = 0;
+  });
+
+  await handleUpdate(event, channel);
+});
+
+ipcMain.on(ChannelEnum.SET_FIXED_BAND, async (event, arg) => {
+  const channel = ChannelEnum.SET_FIXED_BAND;
+  const size: FixedBandSizeEnum = arg[0];
+
+  state.filters = getDefaultFilters(size);
+
+  await handleUpdateHelper<IFiltersMap>(event, channel, state.filters);
 });
 
 ipcMain.on(ChannelEnum.SET_WINDOW_SIZE, async (event, arg) => {

--- a/src/renderer/AutoEQ.tsx
+++ b/src/renderer/AutoEQ.tsx
@@ -99,38 +99,41 @@ const AutoEQ = () => {
   );
 
   return (
-    <div className="auto-eq">
-      Audio Device:
-      <Dropdown
-        name="Audio Device"
-        options={deviceOptions}
-        value={currentDevice}
-        handleChange={handleDeviceChange}
-        isDisabled={!!globalError}
-        noSelectionPlaceholder={NO_DEVICE_SELECTION}
-        isFilterable
-      />
-      Target Frequency Response:
-      <Dropdown
-        name="Target Frequency Response"
-        options={responseOptions}
-        value={currentResponse}
-        handleChange={(newValue) => setCurrentResponse(newValue)}
-        isDisabled={!!globalError || responses.length === 0}
-        emptyOptionsPlaceholder={NO_RESPONSES}
-        noSelectionPlaceholder={NO_RESPONSE_SELECTION}
-      />
-      <Button
-        className="small"
-        ariaLabel="Apply Auto EQ"
-        isDisabled={
-          !!globalError || currentDevice === '' || currentResponse === ''
-        }
-        handleChange={applyAutoEQ}
-      >
-        Apply
-      </Button>
-    </div>
+    <>
+      <h4 className="auto-eq-title">Auto EQ</h4>
+      <div className="auto-eq">
+        Audio Device:
+        <Dropdown
+          name="Audio Device"
+          options={deviceOptions}
+          value={currentDevice}
+          handleChange={handleDeviceChange}
+          isDisabled={!!globalError}
+          noSelectionPlaceholder={NO_DEVICE_SELECTION}
+          isFilterable
+        />
+        Target Frequency Response:
+        <Dropdown
+          name="Target Frequency Response"
+          options={responseOptions}
+          value={currentResponse}
+          handleChange={(newValue) => setCurrentResponse(newValue)}
+          isDisabled={!!globalError || responses.length === 0}
+          emptyOptionsPlaceholder={NO_RESPONSES}
+          noSelectionPlaceholder={NO_RESPONSE_SELECTION}
+        />
+        <Button
+          className="small"
+          ariaLabel="Apply Auto EQ"
+          isDisabled={
+            !!globalError || currentDevice === '' || currentResponse === ''
+          }
+          handleChange={applyAutoEQ}
+        >
+          Apply
+        </Button>
+      </div>
+    </>
   );
 };
 

--- a/src/renderer/MainContent.tsx
+++ b/src/renderer/MainContent.tsx
@@ -88,7 +88,7 @@ const MainContent = () => {
     </div>
   ) : (
     <>
-      <div className="row main-content-title">
+      <div className="main-content-title">
         <h4>Parametric EQ</h4>
         <Button
           ariaLabel="Clear Gains"
@@ -108,9 +108,7 @@ const MainContent = () => {
               ariaLabel={`${size} Band`}
               isDisabled={false}
               className="small"
-              handleChange={handleFixedBand(
-                size as unknown as FixedBandSizeEnum
-              )}
+              handleChange={handleFixedBand(size as FixedBandSizeEnum)}
             >
               {`${size} Band`}
             </Button>

--- a/src/renderer/MainContent.tsx
+++ b/src/renderer/MainContent.tsx
@@ -17,17 +17,25 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { Fragment, useMemo } from 'react';
-import { MAX_NUM_FILTERS, MIN_NUM_FILTERS } from 'common/constants';
+import {
+  FixedBandSizeEnum,
+  MAX_NUM_FILTERS,
+  MIN_NUM_FILTERS,
+} from 'common/constants';
 import { computeAvgFreq } from 'common/utils';
+import { ErrorDescription } from 'common/errors';
 import FrequencyBand from './components/FrequencyBand';
-import { useAquaContext } from './utils/AquaContext';
+import { FilterActionEnum, useAquaContext } from './utils/AquaContext';
 import './styles/MainContent.scss';
 import AddSliderDivider from './components/AddSliderDivider';
 import Spinner from './icons/Spinner';
 import { sortHelper } from './utils/utils';
+import Button from './widgets/Button';
+import { clearGains, setFixedBand } from './utils/equalizerApi';
 
 const MainContent = () => {
-  const { filters, isLoading } = useAquaContext();
+  const { filters, isLoading, dispatchFilter, setGlobalError } =
+    useAquaContext();
 
   // Store widths for AddSliderDividers and FrequencyBands so we can manually position them
   const DIVIDER_WIDTH = 28;
@@ -51,64 +59,117 @@ const MainContent = () => {
     return [fixedSort, visualSort, map];
   }, [filters]);
 
+  const clearFilterGains = async () => {
+    try {
+      await clearGains();
+      dispatchFilter({
+        type: FilterActionEnum.CLEAR_GAINS,
+      });
+    } catch (e) {
+      setGlobalError(e as ErrorDescription);
+    }
+  };
+
+  const handleFixedBand = (size: FixedBandSizeEnum) => async () => {
+    try {
+      const newFilters = await setFixedBand(size);
+      dispatchFilter({
+        type: FilterActionEnum.INIT,
+        filters: newFilters,
+      });
+    } catch (e) {
+      setGlobalError(e as ErrorDescription);
+    }
+  };
+
   return isLoading ? (
     <div className="center full row">
       <Spinner />
     </div>
   ) : (
-    <div className="center main-content">
-      <div className="col center band-label">
-        <span />
-        <span className="row-label">Filter Type</span>
-        <span className="row-label">Frequency (Hz)</span>
-        <span />
-        <span>+30dB</span>
-        <span />
-        <span>0dB</span>
-        <span />
-        <span>-30dB</span>
-        <span />
-        <span className="row-label">Gain (dB)</span>
-        <span className="row-label">Quality</span>
-        <span />
+    <>
+      <div className="row main-content-title">
+        <h4>Parametric EQ</h4>
+        <Button
+          ariaLabel="Clear Gains"
+          isDisabled={false}
+          className="small"
+          handleChange={clearFilterGains}
+        >
+          Clear Gains
+        </Button>
+        <div />
+        <h5>Fixed Band Configs</h5>
+        {Object.values(FixedBandSizeEnum)
+          .filter((s) => !Number.isNaN(Number(s)))
+          .map((size) => (
+            <Button
+              key={`${size}-band`}
+              ariaLabel={`${size} Band`}
+              isDisabled={false}
+              className="small"
+              handleChange={handleFixedBand(
+                size as unknown as FixedBandSizeEnum
+              )}
+            >
+              {`${size} Band`}
+            </Button>
+          ))}
       </div>
-      <div className="bands row center">
-        <AddSliderDivider
-          newSliderFrequency={computeAvgFreq(null, freqSortedFilters[0])}
-          isMaxSliderCount={idSortedFilters.length >= MAX_NUM_FILTERS}
-        />
-        {idSortedFilters.map((filter) => {
-          const sliderIndex = sortIndexMap[filter.id];
-          return (
-            <Fragment key={`slider-${filter.id}`}>
-              <FrequencyBand
-                filter={filter}
-                isMinSliderCount={idSortedFilters.length <= MIN_NUM_FILTERS}
-                // Manually position the frequency band
-                style={{
-                  transform: `translateX(${
-                    DIVIDER_WIDTH + sliderIndex * (DIVIDER_WIDTH + BAND_WIDTH)
-                  }px)`,
-                }}
-              />
-              <AddSliderDivider
-                newSliderFrequency={computeAvgFreq(
-                  freqSortedFilters[sliderIndex],
-                  freqSortedFilters[sliderIndex + 1]
-                )}
-                isMaxSliderCount={idSortedFilters.length >= MAX_NUM_FILTERS}
-                // Manually position the divider
-                style={{
-                  transform: `translateX(${
-                    (sliderIndex + 1) * (DIVIDER_WIDTH + BAND_WIDTH)
-                  }px)`,
-                }}
-              />
-            </Fragment>
-          );
-        })}
+      <div className="main-content">
+        <div className="col center band-label">
+          <span />
+          <span className="row-label">Filter Type</span>
+          <span className="row-label">Frequency (Hz)</span>
+          <span />
+          <span>+30dB</span>
+          <span />
+          <span>0dB</span>
+          <span />
+          <span>-30dB</span>
+          <span />
+          <span className="row-label">Gain (dB)</span>
+          <span className="row-label">Quality</span>
+          <span />
+        </div>
+        <div className="bands row center">
+          <AddSliderDivider
+            newSliderFrequency={computeAvgFreq(null, freqSortedFilters[0])}
+            isMaxSliderCount={idSortedFilters.length >= MAX_NUM_FILTERS}
+          />
+          {idSortedFilters.map((filter) => {
+            const sliderIndex = sortIndexMap[filter.id];
+            return (
+              <Fragment key={`slider-${filter.id}`}>
+                <FrequencyBand
+                  filter={filter}
+                  isMinSliderCount={idSortedFilters.length <= MIN_NUM_FILTERS}
+                  // Manually position the frequency band
+                  style={{
+                    transform: `translateX(${
+                      DIVIDER_WIDTH + sliderIndex * (DIVIDER_WIDTH + BAND_WIDTH)
+                    }px)`,
+                  }}
+                />
+                <AddSliderDivider
+                  newSliderFrequency={computeAvgFreq(
+                    freqSortedFilters[sliderIndex],
+                    freqSortedFilters[sliderIndex + 1]
+                  )}
+                  isMaxSliderCount={idSortedFilters.length >= MAX_NUM_FILTERS}
+                  // Manually position the divider
+                  style={{
+                    transform: `translateX(${
+                      (sliderIndex + 1) * (DIVIDER_WIDTH + BAND_WIDTH)
+                    }px)`,
+                  }}
+                />
+              </Fragment>
+            );
+          })}
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/renderer/components/FrequencyBand.tsx
+++ b/src/renderer/components/FrequencyBand.tsx
@@ -219,7 +219,7 @@ const FrequencyBand = forwardRef(
 
     const sliderHeight = useMemo(
       // Manually determine slider height
-      () => (isGraphViewOn ? '228px' : 'calc(100vh - 398px)'),
+      () => (isGraphViewOn ? '161px' : 'calc(100vh - 465px)'),
       [isGraphViewOn]
     );
 

--- a/src/renderer/styles/App.scss
+++ b/src/renderer/styles/App.scss
@@ -61,7 +61,7 @@ body {
 .middle-content {
   grid-area: middle-content;
   display: grid;
-  grid-template-rows: max-content 1fr;
+  grid-template-rows: repeat(3, max-content) 1fr;
   gap: $spacing-s;
 }
 

--- a/src/renderer/styles/AutoEQ.scss
+++ b/src/renderer/styles/AutoEQ.scss
@@ -22,13 +22,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 $auto-eq-dropdown-width: 220px;
 
+.auto-eq-title {
+  margin: 0 $spacing-s;
+}
+
 .auto-eq {
   display: grid;
   grid-template-columns: max-content minmax(0, 1fr) max-content minmax(0, 1fr) max-content;
   height: min-content;
 
   padding: $spacing-s $spacing-m;
-  border-radius: $spacing-m;
+  border-radius: $spacing-s;
   background: $primary-default;
 
   align-items: center;

--- a/src/renderer/styles/Button.scss
+++ b/src/renderer/styles/Button.scss
@@ -38,6 +38,7 @@ $button-height: 100px;
   &.small {
     padding: $spacing-xs $spacing-s;
     height: fit-content;
+    font-size: small;
   }
 
   &.default {

--- a/src/renderer/styles/MainContent.scss
+++ b/src/renderer/styles/MainContent.scss
@@ -21,6 +21,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 @import 'spacing';
 
 // band width and height from constants file
+.main-content-title {
+  display: grid;
+  grid-template-columns: repeat(2, max-content) 1fr repeat(5, max-content);
+  align-items: center;
+
+  h4,
+  h5,
+  h6 {
+    margin: 0 $spacing-s;
+  }
+}
 
 .main-content {
   display: grid;
@@ -40,7 +51,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     display: grid;
 
     grid-template-rows:
-      0px // top padding
+      8px // top padding
       30px // filter type
       36px // frequency
       24px // top arrow
@@ -48,7 +59,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       24px // bottom arrow
       36px // gain
       36px // quality
-      0px; // bottom padding
+      16px; // bottom padding
     gap: 8px;
   }
 
@@ -58,7 +69,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     padding: 0 $spacing-xxs; // add some horizontal padding so the outline isn't cut off at either end
     height: 100%;
     width: 100%;
-    overflow-x: auto;
+
+    // Keep scrollbar visible to prevent filters' container height from changing
+    overflow-x: scroll;
     overflow-y: hidden;
   }
 }

--- a/src/renderer/utils/AquaContext.tsx
+++ b/src/renderer/utils/AquaContext.tsx
@@ -44,6 +44,8 @@ export enum FilterActionEnum {
   TYPE,
   ADD,
   REMOVE,
+  CLEAR_GAINS,
+  FIXED_BAND,
 }
 
 type NumericalFilterAction =
@@ -56,7 +58,8 @@ export type FilterAction =
   | { type: NumericalFilterAction; id: string; newValue: number }
   | { type: FilterActionEnum.TYPE; id: string; newValue: FilterTypeEnum }
   | { type: FilterActionEnum.ADD; id: string; frequency: number }
-  | { type: FilterActionEnum.REMOVE; id: string };
+  | { type: FilterActionEnum.REMOVE; id: string }
+  | { type: FilterActionEnum.CLEAR_GAINS };
 
 type FilterDispatch = (action: FilterAction) => void;
 
@@ -118,6 +121,13 @@ const filterReducer: IFilterReducer = (
     case FilterActionEnum.REMOVE: {
       const filtersCloned = cloneFilters(filters);
       delete filtersCloned[action.id];
+      return filtersCloned;
+    }
+    case FilterActionEnum.CLEAR_GAINS: {
+      const filtersCloned = cloneFilters(filters);
+      Object.values(filtersCloned).forEach((f) => {
+        f.gain = 0;
+      });
       return filtersCloned;
     }
     default:

--- a/src/renderer/utils/equalizerApi.ts
+++ b/src/renderer/utils/equalizerApi.ts
@@ -24,6 +24,8 @@ import {
 } from 'common/errors';
 import {
   FilterTypeEnum,
+  FixedBandSizeEnum,
+  IFiltersMap,
   IState,
   MAX_FREQUENCY,
   MAX_GAIN,
@@ -71,7 +73,14 @@ const promisifyResult = <Type>(
 };
 
 const buildResponseHandler = <
-  Type extends string | number | boolean | void | IState | string[]
+  Type extends
+    | string
+    | number
+    | boolean
+    | void
+    | IState
+    | IFiltersMap
+    | string[]
 >(
   resultEvaluator: (
     result: Type,
@@ -94,7 +103,14 @@ const buildResponseHandler = <
 };
 
 const simpleResponseHandler = <
-  Type extends string | number | boolean | void | IState | string[]
+  Type extends
+    | string
+    | number
+    | boolean
+    | void
+    | IState
+    | IFiltersMap
+    | string[]
 >() =>
   buildResponseHandler<Type>((result, resolve) => {
     resolve(result);
@@ -461,6 +477,30 @@ export const removeEqualizerSlider = (filterId: string): Promise<void> => {
   const channel = ChannelEnum.REMOVE_FILTER;
   window.electron.ipcRenderer.sendMessage(channel, [filterId]);
   return promisifyResult(setterResponseHandler, channel);
+};
+
+/**
+ * Clear gains for all filters
+ * @returns { Promise<void> } exception if failed
+ */
+export const clearGains = (): Promise<void> => {
+  const channel = ChannelEnum.CLEAR_GAINS;
+  window.electron.ipcRenderer.sendMessage(channel, []);
+  return promisifyResult(setterResponseHandler, channel);
+};
+
+/**
+ * Sets filters to be the corresponding fixed band configuration
+ * @param { FixedBandSizeEnum } size - Number of bands in the fixed configuration
+ * @returns { Promise<void> } exception if failed
+ */
+export const setFixedBand = (size: FixedBandSizeEnum): Promise<IFiltersMap> => {
+  const channel = ChannelEnum.SET_FIXED_BAND;
+  window.electron.ipcRenderer.sendMessage(channel, [size]);
+  return promisifyResult<IFiltersMap>(
+    simpleResponseHandler<IFiltersMap>(),
+    channel
+  );
 };
 
 /**


### PR DESCRIPTION
# Summary
- Add option to clear gains on all filters
- Add options to reset parametric EQ to a fixed band EQ

## Core Changes
- Add headers for the "Auto EQ" and "Parametric EQ" sections
- Add constants for the frequencies for fixed bands
- Add new functions `clearGains` and `setFixedBand`
- Add buttons in the UI to clear gains and set fixed bands

## Miscellaneous
- Shrink size of the sliders to accommodate new headers

## Screenshots
![image](https://github.com/h39s/AQUA/assets/30204513/581bb374-fffb-4ae9-ba1f-c1fc5a488de3)